### PR TITLE
Disable recovered_fp_btc_sk validation in SlashedBtcDelegation

### DIFF
--- a/packages/apis/src/validate.rs
+++ b/packages/apis/src/validate.rs
@@ -185,9 +185,9 @@ impl Validate for SlashedBtcDelegation {
             return Err(StakingApiError::InvalidStakingTxHash(HASH_SIZE * 2));
         }
 
-        if self.recovered_fp_btc_sk.is_empty() {
-            return Err(StakingApiError::EmptyBtcSk);
-        }
+        // if self.recovered_fp_btc_sk.is_empty() {
+        //     return Err(StakingApiError::EmptyBtcSk);
+        // }
 
         Ok(())
     }


### PR DESCRIPTION
The Slashed Delegation IBC packet from Babylon -> Consumer expects to have FP SK, imo this is not needed in the contract side as it has nothing to do with the extracted key. 

For now i have disabled the validation which happens on packet receive, in later pr i'll need to fix the proto files both in babylon side and contract side. 

Ref https://github.com/babylonlabs-io/babylon/blob/7942dae93db7f61539e4f84ecc3ff67f32299f44/proto/babylon/btcstaking/v1/packet.proto#L136