### PR TITLE
feat: add whitelist for reorg handling

### DIFF
--- a/contracts/op-finality-gadget/src/contract.rs
+++ b/contracts/op-finality-gadget/src/contract.rs
@@ -9,6 +9,7 @@ use crate::queries::{
     query_forked_blocks_in_range, query_is_block_forked, query_last_pub_rand_commit,
 };
 use crate::state::config::{Config, ADMIN, CONFIG, IS_ENABLED};
+use crate::state::finality::FORKED_BLOCKS;
 use cosmwasm_std::{
     to_json_binary, Deps, DepsMut, Env, MessageInfo, QueryResponse, Response, StdResult,
 };
@@ -28,6 +29,9 @@ pub fn instantiate(
         consumer_id: msg.consumer_id,
     };
     CONFIG.save(deps.storage, &config)?;
+
+    let forked_blocks: Vec<(u64, u64)> = vec![];
+    FORKED_BLOCKS.save(deps.storage, &forked_blocks)?;
 
     Ok(Response::new().add_attribute("action", "instantiate"))
 }

--- a/contracts/op-finality-gadget/src/contract.rs
+++ b/contracts/op-finality-gadget/src/contract.rs
@@ -5,8 +5,8 @@ use crate::exec::finality::{
 };
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::queries::{
-    query_block_voters, query_config, query_first_pub_rand_commit, query_forked_blocks_in_range,
-    query_is_block_forked, query_last_pub_rand_commit,
+    query_block_voters, query_config, query_first_pub_rand_commit, query_forked_blocks,
+    query_forked_blocks_in_range, query_is_block_forked, query_last_pub_rand_commit,
 };
 use crate::state::config::{Config, ADMIN, CONFIG, IS_ENABLED};
 use cosmwasm_std::{
@@ -45,6 +45,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
         QueryMsg::LastPubRandCommit { btc_pk_hex } => Ok(to_json_binary(
             &query_last_pub_rand_commit(deps.storage, &btc_pk_hex)?,
         )?),
+        QueryMsg::ForkedBlocks {} => Ok(to_json_binary(&query_forked_blocks(deps)?)?),
         QueryMsg::IsBlockForked { height } => {
             Ok(to_json_binary(&query_is_block_forked(deps, height)?)?)
         }

--- a/contracts/op-finality-gadget/src/error.rs
+++ b/contracts/op-finality-gadget/src/error.rs
@@ -38,6 +38,8 @@ pub enum ContractError {
     NotFoundFinalityProvider(String, String),
     #[error("Failed to query the voting power of the finality provider {0}")]
     FailedFetchVotingPower(String),
+    #[error("Empty block range")]
+    EmptyBlockRange,
     #[error("Caller is not the admin")]
     Unauthorized,
     #[error("Finality gadget is already enabled")]

--- a/contracts/op-finality-gadget/src/exec/admin.rs
+++ b/contracts/op-finality-gadget/src/exec/admin.rs
@@ -31,7 +31,7 @@ pub fn set_enabled(
 }
 
 // Helper function to check caller is contract admin
-fn check_admin(deps: &DepsMut, info: MessageInfo) -> Result<(), ContractError> {
+pub fn check_admin(deps: &DepsMut, info: MessageInfo) -> Result<(), ContractError> {
     // Check caller is admin
     if !ADMIN.is_admin(deps.as_ref(), &info.sender)? {
         return Err(ContractError::Unauthorized {});

--- a/contracts/op-finality-gadget/src/exec/finality.rs
+++ b/contracts/op-finality-gadget/src/exec/finality.rs
@@ -315,6 +315,11 @@ pub fn whitelist_forked_blocks(
     // Check caller is admin
     check_admin(&deps, info)?;
 
+    // Check array is non-empty
+    if forked_blocks.is_empty() {
+        return Err(ContractError::EmptyBlockRange);
+    }
+
     // Append blocks to whitelist
     FORKED_BLOCKS.update::<_, ContractError>(deps.storage, |mut blocks| {
         blocks.extend(forked_blocks);

--- a/contracts/op-finality-gadget/src/msg.rs
+++ b/contracts/op-finality-gadget/src/msg.rs
@@ -36,10 +36,13 @@ pub enum QueryMsg {
     /// `btc_pk_hex` is the BTC public key of the finality provider, in hex format.
     #[returns(Option<PubRandCommit>)]
     LastPubRandCommit { btc_pk_hex: String },
+    /// `ForkedBlocks` returns the list of forked blocks
+    #[returns(Vec<(u64, u64)>)]
+    ForkedBlocks {},
     /// `IsBlockForked` returns whether a given block is forked.
     #[returns(bool)]
     IsBlockForked { height: u64 },
-    /// `ForkedBlocks` returns the list of forked blocks
+    /// `ForkedBlocksInRange` returns the list of forked blocks in a given range
     #[returns(Vec<(u64, u64)>)]
     ForkedBlocksInRange { start: u64, end: u64 },
     /// `IsEnabled` returns whether the finality gadget is enabled.

--- a/contracts/op-finality-gadget/src/msg.rs
+++ b/contracts/op-finality-gadget/src/msg.rs
@@ -36,6 +36,13 @@ pub enum QueryMsg {
     /// `btc_pk_hex` is the BTC public key of the finality provider, in hex format.
     #[returns(Option<PubRandCommit>)]
     LastPubRandCommit { btc_pk_hex: String },
+    /// `IsBlockForked` returns whether a given block is forked.
+    #[returns(bool)]
+    IsBlockForked { height: u64 },
+    /// `ForkedBlocks` returns the list of forked blocks
+    #[returns(Vec<(u64, u64)>)]
+    ForkedBlocksInRange { start: u64, end: u64 },
+    /// `IsEnabled` returns whether the finality gadget is enabled.
     #[returns(bool)]
     IsEnabled {},
 }
@@ -74,6 +81,12 @@ pub enum ExecuteMsg {
         proof: Proof,
         block_hash: Binary,
         signature: Binary,
+    },
+    /// Whitelist forked blocks.
+    ///
+    /// This message can be called by the admin only.
+    WhitelistForkedBlocks {
+        forked_blocks: Vec<(u64, u64)>,
     },
     /// Enable or disable finality gadget.
     ///

--- a/contracts/op-finality-gadget/src/queries.rs
+++ b/contracts/op-finality-gadget/src/queries.rs
@@ -87,6 +87,8 @@ pub fn query_forked_blocks_in_range(
             break;
         }
     }
+    // reverse block ranges so they are ordered from highest to lowest
+    block_ranges.reverse();
     Ok(block_ranges)
 }
 

--- a/contracts/op-finality-gadget/src/queries.rs
+++ b/contracts/op-finality-gadget/src/queries.rs
@@ -1,10 +1,11 @@
 use crate::error::ContractError;
 use crate::state::config::{Config, ADMIN, CONFIG, IS_ENABLED};
-use crate::state::finality::BLOCK_VOTES;
+use crate::state::finality::{BLOCK_VOTES, FORKED_BLOCKS};
 use crate::state::public_randomness::get_pub_rand_commit;
 use babylon_apis::finality_api::PubRandCommit;
 use cosmwasm_std::{Deps, StdResult, Storage};
 use cw_controllers::AdminResponse;
+use std::cmp::{max, min};
 use std::collections::HashSet;
 
 pub fn query_config(deps: Deps) -> StdResult<Config> {
@@ -44,6 +45,45 @@ pub fn query_last_pub_rand_commit(
 ) -> Result<Option<PubRandCommit>, ContractError> {
     let res = get_pub_rand_commit(storage, fp_btc_pk_hex, None, Some(1), Some(true))?;
     Ok(res.into_iter().next())
+}
+
+pub fn query_is_block_forked(deps: Deps, height: u64) -> StdResult<bool> {
+    // loop over forked blocks, starting from last entry
+    let forked_blocks = FORKED_BLOCKS.load(deps.storage)?;
+    for (start, end) in forked_blocks.iter().rev() {
+        // if block is in range of any forked block, return true
+        if height >= *start && height <= *end {
+            return Ok(true);
+        }
+        // terminate early once we reach a forked block range lower than the queried block
+        if height < *start {
+            break;
+        }
+    }
+    Ok(false)
+}
+
+pub fn query_forked_blocks_in_range(
+    deps: Deps,
+    start: u64,
+    end: u64,
+) -> StdResult<Vec<(u64, u64)>> {
+    // loop over forked blocks, starting from last entry
+    let mut block_ranges = Vec::new();
+    let forked_blocks = FORKED_BLOCKS.load(deps.storage)?;
+    for (fork_start, fork_end) in forked_blocks.iter().rev() {
+        // append any overlapping forked block ranges to the list, moving cursor forward
+        let overlap_start = max(*fork_start, start);
+        let overlap_end = min(*fork_end, end);
+        if overlap_start <= overlap_end {
+            block_ranges.push((overlap_start, overlap_end));
+        }
+        // terminate early once we reach a forked block range lower than the queried block
+        if *fork_start < start {
+            break;
+        }
+    }
+    Ok(block_ranges)
 }
 
 pub fn query_is_enabled(deps: Deps) -> StdResult<bool> {

--- a/contracts/op-finality-gadget/src/queries.rs
+++ b/contracts/op-finality-gadget/src/queries.rs
@@ -47,6 +47,10 @@ pub fn query_last_pub_rand_commit(
     Ok(res.into_iter().next())
 }
 
+pub fn query_forked_blocks(deps: Deps) -> StdResult<Vec<(u64, u64)>> {
+    FORKED_BLOCKS.load(deps.storage)
+}
+
 pub fn query_is_block_forked(deps: Deps, height: u64) -> StdResult<bool> {
     // loop over forked blocks, starting from last entry
     let forked_blocks = FORKED_BLOCKS.load(deps.storage)?;

--- a/contracts/op-finality-gadget/src/state/finality.rs
+++ b/contracts/op-finality-gadget/src/state/finality.rs
@@ -1,4 +1,4 @@
-use cw_storage_plus::Map;
+use cw_storage_plus::{Item, Map};
 use std::collections::HashSet;
 
 /// Map of signatures by block height and fp
@@ -6,3 +6,6 @@ pub(crate) const SIGNATURES: Map<(u64, &str), Vec<u8>> = Map::new("fp_sigs");
 
 /// Map of (block height, block hash) tuples to the list of fps that voted for this combination
 pub(crate) const BLOCK_VOTES: Map<(u64, &[u8]), HashSet<String>> = Map::new("block_hashes");
+
+/// Ordered list of forked blocks [(start_height_1, end_height_1), (start_height_2, end_height_2), ...]
+pub(crate) const FORKED_BLOCKS: Item<Vec<(u64, u64)>> = Item::new("forked_blocks");

--- a/contracts/op-finality-gadget/tests/enabled.rs
+++ b/contracts/op-finality-gadget/tests/enabled.rs
@@ -3,43 +3,10 @@ use cosmwasm_vm::testing::{
     execute, instantiate, mock_env, mock_info, mock_instance, query, MockApi,
 };
 
-use cw_controllers::AdminResponse;
 use op_finality_gadget::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use op_finality_gadget::state::config::Config;
 
 static WASM: &[u8] = include_bytes!("../../../artifacts/op_finality_gadget.wasm");
 const CREATOR: &str = "creator";
-
-#[test]
-fn instantiate_works() {
-    // Setup
-    let mut deps = mock_instance(WASM, &[]);
-    let mock_api: MockApi = MockApi::default();
-    let msg = InstantiateMsg {
-        admin: mock_api.addr_make(CREATOR),
-        consumer_id: "op-stack-l2-11155420".to_string(),
-        is_enabled: false,
-    };
-    let info = mock_info(CREATOR, &[]);
-    let res: ContractResult<Response> = instantiate(&mut deps, mock_env(), info, msg.clone());
-    let msgs = res.unwrap().messages;
-    assert_eq!(0, msgs.len());
-
-    // Check the config is properly stored in the state and returned
-    let res: Config =
-        from_json(query(&mut deps, mock_env(), QueryMsg::Config {}).unwrap()).unwrap();
-    assert_eq!(msg.consumer_id, res.consumer_id);
-
-    // Check the admin is properly stored in the state and returned
-    let res: AdminResponse =
-        from_json(query(&mut deps, mock_env(), QueryMsg::Admin {}).unwrap()).unwrap();
-    assert_eq!(mock_api.addr_make(CREATOR), res.admin.unwrap());
-
-    // Check the contract is disabled on instantiation
-    let enabled: bool =
-        from_json(query(&mut deps, mock_env(), QueryMsg::IsEnabled {}).unwrap()).unwrap();
-    assert!(!enabled);
-}
 
 #[test]
 fn disable_and_reenable_works() {

--- a/contracts/op-finality-gadget/tests/forked_blocks.rs
+++ b/contracts/op-finality-gadget/tests/forked_blocks.rs
@@ -1,0 +1,226 @@
+use cosmwasm_std::{from_json, ContractResult, Response};
+use cosmwasm_vm::testing::{
+    execute, instantiate, mock_env, mock_info, mock_instance, query, MockApi,
+};
+
+use op_finality_gadget::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+static WASM: &[u8] = include_bytes!("../../../artifacts/op_finality_gadget.wasm");
+const CREATOR: &str = "creator";
+
+// Test cases:
+// 1. Success case: checking is block forked returns false for empty forked blocks array
+// 2. Success case: checking is block forked in forked block range returns true
+// 3. Success case: checking is block forked outside (after) forked block range returns false
+// 4. Success case: checking is block forked outside (before) forked block range returns false
+// 5. Success case: checking forked blocks in range returns empty list for non-overlapping block range
+// 6. Success case: checking forked blocks in range returns list of forked blocks for single overlapping block range
+// 7. Success case: checking forked blocks in range returns list of forked blocks for multiple overlapping block ranges
+// 8. Fail case: Non-admin caller cannot whitelist forked blocks
+
+#[test]
+fn no_forked_blocks() {
+    test_forked_block_helper(vec![], 1, false, "no forked blocks");
+}
+
+#[test]
+fn forked_block_in_range_start() {
+    test_forked_block_helper(vec![(1, 10)], 1, true, "forked block in range");
+}
+
+#[test]
+fn forked_block_in_range_middle() {
+    test_forked_block_helper(vec![(1, 10)], 5, true, "forked block in range");
+}
+
+#[test]
+fn forked_block_in_range_end() {
+    test_forked_block_helper(vec![(1, 10)], 10, true, "forked block in range");
+}
+
+#[test]
+fn forked_blocks_in_range_non_overlapping() {
+    test_forked_block_range_helper(
+        vec![(1, 10), (15, 20)],
+        13,
+        14,
+        vec![],
+        "block ranges not overlapping",
+    );
+}
+
+#[test]
+fn forked_blocks_in_range_single_overlapping() {
+    test_forked_block_range_helper(
+        vec![(1, 10), (15, 20)],
+        6,
+        12,
+        vec![(6, 10)],
+        "single overlapping block range",
+    );
+}
+
+#[test]
+fn forked_blocks_in_range_multiple_overlapping() {
+    test_forked_block_range_helper(
+        vec![(1, 10), (15, 20)],
+        6,
+        17,
+        vec![(6, 10), (15, 17)],
+        "multiple overlapping block ranges",
+    );
+}
+
+#[test]
+#[should_panic(expected = "Empty block range")]
+fn whitelist_empty_block_range() {
+    let mut instance = mock_instance(WASM, &[]);
+    let mock_api = MockApi::default();
+    let msg = InstantiateMsg {
+        admin: mock_api.addr_make(CREATOR),
+        consumer_id: "op-stack-l2-11155420".to_string(),
+        is_enabled: true,
+    };
+    let info = mock_info(CREATOR, &[]);
+    let res: ContractResult<Response> = instantiate(&mut instance, mock_env(), info, msg.clone());
+    assert!(res.is_ok());
+
+    // Add forked block as admin caller
+    let info = mock_info(&mock_api.addr_make(CREATOR), &[]);
+    let res: ContractResult<Response> = execute(
+        &mut instance,
+        mock_env(),
+        info,
+        ExecuteMsg::WhitelistForkedBlocks {
+            forked_blocks: vec![],
+        },
+    );
+    res.unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Caller is not the admin")]
+fn whitelist_non_admin_caller() {
+    // Setup
+    let mut instance = mock_instance(WASM, &[]);
+    let mock_api = MockApi::default();
+    let msg = InstantiateMsg {
+        admin: mock_api.addr_make(CREATOR),
+        consumer_id: "op-stack-l2-11155420".to_string(),
+        is_enabled: true,
+    };
+    let info = mock_info(CREATOR, &[]);
+    let res: ContractResult<Response> = instantiate(&mut instance, mock_env(), info, msg.clone());
+    assert!(res.is_ok());
+
+    // Add forked block as admin caller
+    let caller = mock_api.addr_make("caller");
+    let info = mock_info(&caller, &[]);
+    let res: ContractResult<Response> = execute(
+        &mut instance,
+        mock_env(),
+        info,
+        ExecuteMsg::WhitelistForkedBlocks {
+            forked_blocks: vec![(1, 10)],
+        },
+    );
+    res.unwrap();
+}
+
+// Helper functions
+
+fn test_forked_block_helper(
+    whitelist_blocks: Vec<(u64, u64)>,
+    query_height: u64,
+    exp_is_forked: bool,
+    exp_msg: &str,
+) {
+    // Setup
+    let mut instance = mock_instance(WASM, &[]);
+    let mock_api = MockApi::default();
+    let msg = InstantiateMsg {
+        admin: mock_api.addr_make(CREATOR),
+        consumer_id: "op-stack-l2-11155420".to_string(),
+        is_enabled: true,
+    };
+    let info = mock_info(CREATOR, &[]);
+    let res: ContractResult<Response> = instantiate(&mut instance, mock_env(), info, msg.clone());
+    assert!(res.is_ok());
+
+    // Add forked block as admin caller
+    if !whitelist_blocks.is_empty() {
+        let info = mock_info(&mock_api.addr_make(CREATOR), &[]);
+        let res: ContractResult<Response> = execute(
+            &mut instance,
+            mock_env(),
+            info,
+            ExecuteMsg::WhitelistForkedBlocks {
+                forked_blocks: whitelist_blocks,
+            },
+        );
+        assert!(res.is_ok());
+    }
+
+    // Check is block forked
+    let is_forked: bool = from_json(
+        query(
+            &mut instance,
+            mock_env(),
+            QueryMsg::IsBlockForked {
+                height: query_height,
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(is_forked == exp_is_forked, "{}", exp_msg);
+}
+
+fn test_forked_block_range_helper(
+    whitelist_blocks: Vec<(u64, u64)>,
+    query_start: u64,
+    query_end: u64,
+    exp_forked_blocks: Vec<(u64, u64)>,
+    exp_msg: &str,
+) {
+    // Setup
+    let mut instance = mock_instance(WASM, &[]);
+    let mock_api = MockApi::default();
+    let msg = InstantiateMsg {
+        admin: mock_api.addr_make(CREATOR),
+        consumer_id: "op-stack-l2-11155420".to_string(),
+        is_enabled: true,
+    };
+    let info = mock_info(CREATOR, &[]);
+    let res: ContractResult<Response> = instantiate(&mut instance, mock_env(), info, msg.clone());
+    assert!(res.is_ok());
+
+    // Add forked block as admin caller
+    if !whitelist_blocks.is_empty() {
+        let info: cosmwasm_std::MessageInfo = mock_info(&mock_api.addr_make(CREATOR), &[]);
+        let res: ContractResult<Response> = execute(
+            &mut instance,
+            mock_env(),
+            info,
+            ExecuteMsg::WhitelistForkedBlocks {
+                forked_blocks: whitelist_blocks,
+            },
+        );
+        assert!(res.is_ok());
+    }
+
+    // Check is block forked
+    let forked_blocks: Vec<(u64, u64)> = from_json(
+        query(
+            &mut instance,
+            mock_env(),
+            QueryMsg::ForkedBlocksInRange {
+                start: query_start,
+                end: query_end,
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(forked_blocks == exp_forked_blocks, "{}", exp_msg);
+}

--- a/contracts/op-finality-gadget/tests/instantiate.rs
+++ b/contracts/op-finality-gadget/tests/instantiate.rs
@@ -1,0 +1,45 @@
+use cosmwasm_std::{from_json, ContractResult, Response};
+use cosmwasm_vm::testing::{instantiate, mock_env, mock_info, mock_instance, query, MockApi};
+
+use cw_controllers::AdminResponse;
+use op_finality_gadget::msg::{InstantiateMsg, QueryMsg};
+use op_finality_gadget::state::config::Config;
+
+static WASM: &[u8] = include_bytes!("../../../artifacts/op_finality_gadget.wasm");
+const CREATOR: &str = "creator";
+
+#[test]
+fn instantiate_works() {
+    // Setup
+    let mut deps = mock_instance(WASM, &[]);
+    let mock_api: MockApi = MockApi::default();
+    let msg = InstantiateMsg {
+        admin: mock_api.addr_make(CREATOR),
+        consumer_id: "op-stack-l2-11155420".to_string(),
+        is_enabled: false,
+    };
+    let info = mock_info(CREATOR, &[]);
+    let res: ContractResult<Response> = instantiate(&mut deps, mock_env(), info, msg.clone());
+    let msgs = res.unwrap().messages;
+    assert_eq!(0, msgs.len());
+
+    // Check the config is properly stored in the state and returned
+    let res: Config =
+        from_json(query(&mut deps, mock_env(), QueryMsg::Config {}).unwrap()).unwrap();
+    assert_eq!(msg.consumer_id, res.consumer_id);
+
+    // Check the admin is properly stored in the state and returned
+    let res: AdminResponse =
+        from_json(query(&mut deps, mock_env(), QueryMsg::Admin {}).unwrap()).unwrap();
+    assert_eq!(mock_api.addr_make(CREATOR), res.admin.unwrap());
+
+    // Check the contract is disabled on instantiation
+    let enabled: bool =
+        from_json(query(&mut deps, mock_env(), QueryMsg::IsEnabled {}).unwrap()).unwrap();
+    assert!(!enabled);
+
+    // Check the forked blocks array is empty on instantiation
+    let forked_blocks: Vec<(u64, u64)> =
+        from_json(query(&mut deps, mock_env(), QueryMsg::ForkedBlocks {}).unwrap()).unwrap();
+    assert_eq!(0, forked_blocks.len());
+}


### PR DESCRIPTION
## Summary

This PR adds whitelisting for reorg handling. 

The current FG cannot handle L2 block reorgs because the new block hash breaks the finality votes query. This causes the finalized head to become stuck. 

We implement a new whitelist system in the CW contract to allow:
- a privileged admin to add whitelisted blocks
- FG to check blocks against the whitelist and skip them to unblock the derivation pipeline

## Test plan

```
cargo build
cargo optimize
cargo test
```