### PR TITLE
refactor: standardize usage of Bitcoin chain parameters

### DIFF
--- a/contracts/btc-light-client/src/utils/btc_light_client.rs
+++ b/contracts/btc-light-client/src/utils/btc_light_client.rs
@@ -7,7 +7,7 @@ use std::str::{from_utf8, FromStr};
 /// verify_headers verifies whether `new_headers` are valid consecutive headers
 /// after the given `first_header`
 pub fn verify_headers(
-    btc_network: &babylon_bitcoin::chain_params::Params,
+    chain_params: &babylon_bitcoin::chain_params::Params,
     first_header: &BtcHeaderInfo,
     new_headers: &[BtcHeaderInfo],
 ) -> Result<(), error::ContractError> {
@@ -24,7 +24,7 @@ pub fn verify_headers(
             .map_err(|_| error::ContractError::BTCHeaderDecodeError {})?;
 
         // validate whether btc_header extends last_btc_header
-        babylon_bitcoin::pow::verify_next_header_pow(btc_network, &last_btc_header, &btc_header)
+        babylon_bitcoin::pow::verify_next_header_pow(chain_params, &last_btc_header, &btc_header)
             .map_err(|_| error::ContractError::BTCHeaderError {})?;
 
         let header_work = btc_header.work();

--- a/packages/bitcoin/src/chain_params.rs
+++ b/packages/bitcoin/src/chain_params.rs
@@ -13,20 +13,22 @@ pub enum Network {
     Regtest,
 }
 
-pub fn get_chain_params(net: Network) -> Params {
-    match net {
-        Network::Mainnet => Params::new(bitcoin::Network::Bitcoin),
-        Network::Testnet => Params::new(bitcoin::Network::Testnet),
-        Network::Signet => Params::new(bitcoin::Network::Signet),
-        Network::Regtest => Params::new(bitcoin::Network::Regtest),
+impl Network {
+    pub fn chain_params(&self) -> Params {
+        match self {
+            Self::Mainnet => Params::new(bitcoin::Network::Bitcoin),
+            Self::Testnet => Params::new(bitcoin::Network::Testnet),
+            Self::Signet => Params::new(bitcoin::Network::Signet),
+            Self::Regtest => Params::new(bitcoin::Network::Regtest),
+        }
     }
-}
 
-pub fn get_bitcoin_network(net: Network) -> bitcoin::Network {
-    match net {
-        Network::Mainnet => bitcoin::Network::Bitcoin,
-        Network::Testnet => bitcoin::Network::Testnet,
-        Network::Signet => bitcoin::Network::Signet,
-        Network::Regtest => bitcoin::Network::Regtest,
+    pub fn bitcoin_network(&self) -> bitcoin::Network {
+        match self {
+            Self::Mainnet => bitcoin::Network::Bitcoin,
+            Self::Testnet => bitcoin::Network::Testnet,
+            Self::Signet => bitcoin::Network::Signet,
+            Self::Regtest => bitcoin::Network::Regtest,
+        }
     }
 }


### PR DESCRIPTION
- Replaced all calls to `get_chain_params(cfg.network)` with `cfg.network.chain_params()` for consistency.
- Replace inproper `btc_network` variable in favor of unified `chain_params`.

As I get more familiar with the codebase, I’ll likely send in a few minor refactoring PRs — nothing functional, just cleanup and consistency.