### PR TITLE
fix: avoid output filename collision warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,11 +102,7 @@ jobs:
         asset_name: checksums.txt
         asset_content_type: text/plain
     - name: Build and run schema generator
-      run: |-
-        (cd ./contracts/babylon && cargo run --bin schema)
-        (cd ./contracts/btc-staking && cargo run --bin btc-staking-schema)
-        (cd ./contracts/btc-finality && cargo run --bin btc-finality-schema)
-        (cd ./contracts/btc-light-client && cargo run --bin btc-light-client-schema)
+      run: bash schema.sh
     - name: Consolidate schemas
       run: |-
         mkdir -p ./schemas

--- a/.github/workflows/local-tests.yml
+++ b/.github/workflows/local-tests.yml
@@ -6,6 +6,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
 jobs:
+  check-schema-binary-naming:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - name: Check schema binary naming convention
+      run: bash scripts/check-schema-naming.sh
   local-build-test:
     runs-on: ubuntu-latest
     container:

--- a/contracts/babylon/Cargo.toml
+++ b/contracts/babylon/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 doctest = false
 
 [[bin]]
-name = "schema"
+name = "babylon-schema"
 path = "src/bin/schema.rs"
 bench = false
 test = false

--- a/contracts/btc-light-client/Cargo.toml
+++ b/contracts/btc-light-client/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 doctest = false
 
 [[bin]]
-name = "schema"
+name = "btc-light-client-schema"
 path = "src/bin/schema.rs"
 bench = false
 test = false
@@ -60,4 +60,4 @@ thousands              = { workspace = true }
 
 [[bench]]
 name = "main"
-harness = false 
+harness = false

--- a/scripts/check-schema-naming.sh
+++ b/scripts/check-schema-naming.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Script to check that schema binary names follow the format $crate-schema
+# This script validates the naming convention defined in scripts/schema.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Checking schema binary naming convention..."
+echo "Expected format: \$crate-schema (where \$crate is the contract directory name)"
+echo
+
+FAILED=0
+TOTAL_CONTRACTS=0
+
+# Check each contract directory
+for CONTRACT_DIR in "$PROJECT_ROOT"/contracts/*/; do
+    if [ ! -d "$CONTRACT_DIR" ]; then
+        continue
+    fi
+
+    CRATE_NAME=$(basename "$CONTRACT_DIR")
+    EXPECTED_SCHEMA_NAME="$CRATE_NAME-schema"
+    CARGO_TOML="$CONTRACT_DIR/Cargo.toml"
+
+    TOTAL_CONTRACTS=$((TOTAL_CONTRACTS + 1))
+
+    echo "Checking contract: $CRATE_NAME"
+    echo "  Expected schema binary name: $EXPECTED_SCHEMA_NAME"
+
+    if [ ! -f "$CARGO_TOML" ]; then
+        echo "  ❌ ERROR: Cargo.toml not found in $CONTRACT_DIR"
+        FAILED=$((FAILED + 1))
+        continue
+    fi
+
+    # Extract the schema binary name from Cargo.toml
+    # Look for [[bin]] sections with name containing "schema"
+    SCHEMA_BINARY=$(grep -A 10 '\[\[bin\]\]' "$CARGO_TOML" | grep -B 10 'schema\.rs' | grep '^name = ' | sed 's/name = "\(.*\)"/\1/' | tr -d '"')
+
+    if [ -z "$SCHEMA_BINARY" ]; then
+        echo "  ❌ ERROR: No schema binary found in $CARGO_TOML"
+        FAILED=$((FAILED + 1))
+        continue
+    fi
+
+    echo "  Found schema binary name: $SCHEMA_BINARY"
+
+    if [ "$SCHEMA_BINARY" = "$EXPECTED_SCHEMA_NAME" ]; then
+        echo "  ✅ PASS: Schema binary name matches expected format"
+    else
+        echo "  ❌ FAIL: Schema binary name does not match expected format"
+        echo "    Expected: $EXPECTED_SCHEMA_NAME"
+        echo "    Found: $SCHEMA_BINARY"
+        FAILED=$((FAILED + 1))
+    fi
+
+    echo
+done
+
+echo "Summary:"
+echo "  Total contracts checked: $TOTAL_CONTRACTS"
+echo "  Failed checks: $FAILED"
+echo "  Passed checks: $((TOTAL_CONTRACTS - FAILED))"
+
+if [ $FAILED -eq 0 ]; then
+    echo
+    echo "🎉 All schema binary names follow the correct naming convention!"
+    exit 0
+else
+    echo
+    echo "💥 $FAILED contract(s) have incorrect schema binary names!"
+    echo "Please ensure all schema binaries follow the format: \$crate-schema"
+    echo "Where \$crate is the name of the contract directory."
+    exit 1
+fi

--- a/scripts/schema.sh
+++ b/scripts/schema.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-
-for CONTRACT in ./contracts/*/
-do
-  (cd $CONTRACT && cargo schema)
+for CONTRACT in ./contracts/*/; do
+  CRATE_NAME=$(basename "$CONTRACT")
+  echo "Generating schema for $CRATE_NAME..."
+  (cd $CONTRACT && cargo run --bin "$CRATE_NAME-schema")
 done

--- a/scripts/set_version.sh
+++ b/scripts/set_version.sh
@@ -42,9 +42,9 @@ FILES_MODIFIED+=("$CARGO_TOML")
 cargo build
 FILES_MODIFIED+=("Cargo.lock")
 
-for CONTRACT in ./contracts/*/
-do
-  (cd "$CONTRACT" && cargo schema)
+for CONTRACT in ./contracts/*/; do
+  CRATE_NAME=$(basename "$CONTRACT")
+  (cd "$CONTRACT" && cargo run --bin "$CRATE_NAME-schema")
   FILES_MODIFIED+=("$CONTRACT"/schema/)
 done
 


### PR DESCRIPTION
Currently, you'll see the following warning when running `cargo build`:

```
warning: output filename collision.
The bin target `schema` in package `btc-light-client v0.14.0 (/Users/xuliucheng/src/github.com/babylonlabs-io/cosmos-bsn-contracts/contracts/btc-light-client)` has the same output filename as the bin target `schema` in package `babylon-contract v0.14.0 (/Users/xuliucheng/src/github.com/babylonlabs-io/cosmos-bsn-contracts/contracts/babylon)`.
Colliding filename is: /Users/xuliucheng/src/github.com/babylonlabs-io/cosmos-bsn-contracts/target/debug/schema
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
warning: output filename collision.
The bin target `schema` in package `btc-light-client v0.14.0 (/Users/xuliucheng/src/github.com/babylonlabs-io/cosmos-bsn-contracts/contracts/btc-light-client)` has the same output filename as the bin target `schema` in package `babylon-contract v0.14.0 (/Users/xuliucheng/src/github.com/babylonlabs-io/cosmos-bsn-contracts/contracts/babylon)`.
Colliding filename is: /Users/xuliucheng/src/github.com/babylonlabs-io/cosmos-bsn-contracts/target/debug/schema.dSYM
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
```

This PR fixes it by renaming the schema binary to be contract-specific. It also fixes the schema generator in `deploy.yml.` 