### PR TITLE
F/publish crates io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ version = "0.14.0"
 dependencies = [
  "babylon-bitcoin",
  "babylon-proto",
+ "babylon-test-utils",
  "bitcoin",
  "digest",
  "eots",
@@ -291,7 +292,6 @@ dependencies = [
  "prost",
  "rust_decimal",
  "sha2",
- "test-utils",
  "thiserror 1.0.69",
 ]
 
@@ -306,6 +306,7 @@ dependencies = [
  "babylon-bindings-test",
  "babylon-bitcoin",
  "babylon-proto",
+ "babylon-test-utils",
  "blst",
  "btc-finality",
  "btc-light-client",
@@ -329,7 +330,6 @@ dependencies = [
  "prost",
  "sha2",
  "tendermint-proto",
- "test-utils",
  "thiserror 1.0.69",
  "thousands",
 ]
@@ -358,6 +358,21 @@ dependencies = [
  "prost",
  "sha2",
  "tendermint-proto",
+]
+
+[[package]]
+name = "babylon-test-utils"
+version = "0.14.0"
+dependencies = [
+ "babylon-apis",
+ "babylon-bitcoin",
+ "babylon-proto",
+ "cosmwasm-std",
+ "hex",
+ "k256",
+ "prost",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -574,6 +589,7 @@ dependencies = [
  "babylon-contract",
  "babylon-merkle",
  "babylon-proto",
+ "babylon-test-utils",
  "bitcoin",
  "btc-light-client",
  "btc-staking",
@@ -592,7 +608,6 @@ dependencies = [
  "pbjson-types",
  "prost",
  "tendermint-proto",
- "test-utils",
  "thiserror 1.0.69",
 ]
 
@@ -607,6 +622,7 @@ dependencies = [
  "babylon-bindings-test",
  "babylon-bitcoin",
  "babylon-proto",
+ "babylon-test-utils",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-vm",
@@ -619,7 +635,6 @@ dependencies = [
  "hex",
  "prost",
  "serde",
- "test-utils",
  "thiserror 1.0.69",
  "thousands",
 ]
@@ -635,6 +650,7 @@ dependencies = [
  "babylon-contract",
  "babylon-merkle",
  "babylon-proto",
+ "babylon-test-utils",
  "bitcoin",
  "btc-light-client",
  "cosmwasm-schema",
@@ -649,7 +665,6 @@ dependencies = [
  "hex",
  "k256",
  "prost",
- "test-utils",
  "thiserror 1.0.69",
 ]
 
@@ -1443,11 +1458,11 @@ dependencies = [
 name = "eots"
 version = "0.14.0"
 dependencies = [
+ "babylon-test-utils",
  "hex",
  "k256",
  "rand",
  "sha2",
- "test-utils",
  "thiserror 1.0.69",
 ]
 
@@ -2890,21 +2905,6 @@ dependencies = [
  "serde_bytes",
  "subtle-encoding",
  "time",
-]
-
-[[package]]
-name = "test-utils"
-version = "0.14.0"
-dependencies = [
- "babylon-apis",
- "babylon-bitcoin",
- "babylon-proto",
- "cosmwasm-std",
- "hex",
- "k256",
- "prost",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/contracts/babylon/.cargo/config.toml
+++ b/contracts/babylon/.cargo/config.toml
@@ -1,4 +1,4 @@
 [alias]
 unit-test = "test --lib"
 integration-test = "test --test integration"
-schema = "run --bin schema"
+schema = "run --bin babylon-schema"

--- a/contracts/babylon/Cargo.toml
+++ b/contracts/babylon/Cargo.toml
@@ -56,11 +56,11 @@ sha2             = { workspace = true }
 btc-light-client = { path = "../btc-light-client", features = [ "library" ] }
 
 [dev-dependencies]
-babylon-bindings-test        = { path = "../../packages/bindings-test" }
-btc-staking                  = { path = "../btc-staking", features = [ "library" ] }
-btc-finality                 = { path = "../btc-finality", features = [ "library" ] }
-btc-light-client             = { path = "../btc-light-client", features = [ "library" ] }
-test-utils                   = { path = "../../packages/test-utils" }
+babylon-bindings-test  = { path = "../../packages/bindings-test" }
+babylon-test-utils     = { path = "../../packages/test-utils" }
+btc-staking            = { path = "../btc-staking", features = [ "library" ] }
+btc-finality           = { path = "../btc-finality", features = [ "library" ] }
+btc-light-client       = { path = "../btc-light-client", features = [ "library" ] }
 
 cosmwasm-vm            = { workspace = true }
 cw-multi-test          = { workspace = true }

--- a/contracts/babylon/src/utils/babylon_epoch_chain.rs
+++ b/contracts/babylon/src/utils/babylon_epoch_chain.rs
@@ -137,7 +137,8 @@ pub fn verify_checkpoint_submitted(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use test_utils::get_btc_timestamp_and_headers;
+
+    use babylon_test_utils::get_btc_timestamp_and_headers;
 
     #[test]
     fn verify_epoch_sealed_works() {

--- a/contracts/btc-finality/Cargo.toml
+++ b/contracts/btc-finality/Cargo.toml
@@ -55,11 +55,12 @@ thiserror        = { workspace = true }
 cw-controllers   = { workspace = true }
 
 [dev-dependencies]
-babylon-bindings-test = { path = "../../packages/bindings-test" }
-babylon-proto         = { path = "../../packages/proto" }
 babylon-contract      = { path = "../babylon", features = [ "library" ] }
 btc-staking           = { path = "../btc-staking", features = [ "library" ] }
-test-utils            = { path = "../../packages/test-utils" }
+
+babylon-bindings-test = { path = "../../packages/bindings-test" }
+babylon-proto         = { path = "../../packages/proto" }
+babylon-test-utils    = { path = "../../packages/test-utils" }
 
 cosmwasm-vm           = { workspace = true }
 cw-multi-test         = { workspace = true }

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -64,13 +64,12 @@ mod finality {
 
     use crate::msg::FinalitySignatureResponse;
     use babylon_apis::finality_api::IndexedBlock;
-    use test_utils::get_public_randomness_commitment;
 
-    use cosmwasm_std::{coin, Event};
-    use test_utils::{
+    use babylon_test_utils::{
         create_new_finality_provider, get_add_finality_sig, get_derived_btc_delegation,
-        get_pub_rand_value,
+        get_pub_rand_value, get_public_randomness_commitment,
     };
+    use cosmwasm_std::{coin, Event};
 
     #[test]
     fn commit_public_randomness_works() {
@@ -343,14 +342,13 @@ mod finality {
 
 mod slashing {
     use babylon_apis::finality_api::IndexedBlock;
-    use cosmwasm_std::coin;
-    use test_utils::{
+    use babylon_test_utils::{
         create_new_finality_provider, get_add_finality_sig, get_add_finality_sig_2,
-        get_derived_btc_delegation, get_pub_rand_value,
+        get_derived_btc_delegation, get_pub_rand_value, get_public_randomness_commitment,
     };
+    use cosmwasm_std::coin;
 
     use crate::multitest::suite::SuiteBuilder;
-    use test_utils::get_public_randomness_commitment;
 
     #[test]
     fn slashing_works() {
@@ -491,14 +489,13 @@ mod slashing {
 
 mod distribution {
     use babylon_apis::finality_api::IndexedBlock;
-    use cosmwasm_std::{coin, Addr};
-    use test_utils::{
+    use babylon_test_utils::{
         create_new_finality_provider, get_add_finality_sig, get_derived_btc_delegation,
-        get_pub_rand_value,
+        get_pub_rand_value, get_public_randomness_commitment,
     };
+    use cosmwasm_std::{coin, Addr};
 
     use crate::multitest::suite::SuiteBuilder;
-    use test_utils::get_public_randomness_commitment;
 
     #[test]
     fn distribution_consumer_withdrawal_works() {
@@ -657,7 +654,7 @@ mod jailing {
 
     use crate::error::ContractError;
     use crate::multitest::suite::SuiteBuilder;
-    use test_utils::{
+    use babylon_test_utils::{
         create_new_finality_provider, get_add_finality_sig, get_derived_btc_delegation,
         get_pub_rand_value, get_public_randomness_commitment,
     };

--- a/contracts/btc-light-client/.cargo/config.toml
+++ b/contracts/btc-light-client/.cargo/config.toml
@@ -1,4 +1,4 @@
 [alias]
 wasm = "build --release --target wasm32-unknown-unknown"
 unit-test = "test --lib"
-schema = "run --bin schema" 
+schema = "run --bin btc-light-client-schema" 

--- a/contracts/btc-light-client/Cargo.toml
+++ b/contracts/btc-light-client/Cargo.toml
@@ -46,7 +46,7 @@ serde            = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 babylon-bindings-test  = { path = "../../packages/bindings-test" }
-test-utils             = { path = "../../packages/test-utils" }
+babylon-test-utils     = { path = "../../packages/test-utils" }
 
 cosmwasm-vm            = { workspace = true }
 cw-multi-test          = { workspace = true }

--- a/contracts/btc-light-client/benches/main.rs
+++ b/contracts/btc-light-client/benches/main.rs
@@ -6,7 +6,6 @@
 use criterion::{criterion_group, criterion_main, Criterion, PlottingBackend};
 
 use std::time::Duration;
-use test_utils::get_btc_lc_mainchain_resp;
 use thousands::Separable;
 
 use cosmwasm_std::{Env, MessageInfo, Response};
@@ -17,6 +16,7 @@ use cosmwasm_vm::testing::{
 use cosmwasm_vm::Instance;
 
 use babylon_bindings::BabylonMsg;
+use babylon_test_utils::get_btc_lc_mainchain_resp;
 use btc_light_client::msg::btc_header::BtcHeader;
 use btc_light_client::msg::contract::{ExecuteMsg, InstantiateMsg};
 

--- a/contracts/btc-light-client/src/queries/btc_header.rs
+++ b/contracts/btc-light-client/src/queries/btc_header.rs
@@ -40,8 +40,8 @@ pub fn btc_headers(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use babylon_test_utils::get_btc_lc_headers;
     use cosmwasm_std::testing::mock_dependencies;
-    use test_utils::get_btc_lc_headers;
 
     use crate::state::btc_light_client::init_from_babylon;
     use crate::state::config::{Config, CONFIG};

--- a/contracts/btc-light-client/src/queries/mod.rs
+++ b/contracts/btc-light-client/src/queries/mod.rs
@@ -9,8 +9,8 @@ mod tests {
     use super::*;
     use crate::state::btc_light_client::init_from_babylon;
     use crate::state::btc_light_client::tests::setup;
+    use babylon_test_utils::get_btc_lc_headers;
     use cosmwasm_std::testing::mock_dependencies;
-    use test_utils::get_btc_lc_headers;
 
     #[test]
     fn btc_headers_work() {

--- a/contracts/btc-light-client/src/state/btc_light_client.rs
+++ b/contracts/btc-light-client/src/state/btc_light_client.rs
@@ -352,8 +352,8 @@ pub mod tests {
 
     use super::*;
     use babylon_bitcoin::chain_params::Network;
+    use babylon_test_utils::{get_btc_lc_fork_headers, get_btc_lc_fork_msg, get_btc_lc_headers};
     use cosmwasm_std::{from_json, testing::mock_dependencies};
-    use test_utils::{get_btc_lc_fork_headers, get_btc_lc_fork_msg, get_btc_lc_headers};
 
     pub(crate) fn setup(storage: &mut dyn Storage) -> u32 {
         // set config first

--- a/contracts/btc-staking/Cargo.toml
+++ b/contracts/btc-staking/Cargo.toml
@@ -37,16 +37,17 @@ library = []
 full-validation = []
 
 [dependencies]
-babylon-apis          = { path = "../../packages/apis" }
-babylon-bindings      = { path = "../../packages/bindings" }
-babylon-contract      = { path = "../babylon", features = [ "library" ] }
-babylon-merkle        = { path = "../../packages/merkle" }
-babylon-proto         = { path = "../../packages/proto" }
-babylon-btcstaking    = { path = "../../packages/btcstaking" }
-babylon-bitcoin       = { path = "../../packages/bitcoin" }
-eots                  = { path = "../../packages/eots" }
-test-utils            = { path = "../../packages/test-utils" }
-btc-light-client      = { path = "../btc-light-client", features = [ "library" ] }
+btc-light-client = { path = "../btc-light-client", features = [ "library" ] }
+
+babylon-apis       = { path = "../../packages/apis" }
+babylon-bindings   = { path = "../../packages/bindings" }
+babylon-contract   = { path = "../babylon", features = [ "library" ] }
+babylon-merkle     = { path = "../../packages/merkle" }
+babylon-proto      = { path = "../../packages/proto" }
+babylon-btcstaking = { path = "../../packages/btcstaking" }
+babylon-bitcoin    = { path = "../../packages/bitcoin" }
+babylon-test-utils = { path = "../../packages/test-utils" }
+eots               = { path = "../../packages/eots" }
 
 bitcoin          = { workspace = true }
 cosmwasm-schema  = { workspace = true }
@@ -62,6 +63,6 @@ thiserror        = { workspace = true }
 cw-controllers   = { workspace = true }
 
 [dev-dependencies]
-babylon-proto     = { path = "../../packages/proto" }
-cosmwasm-vm       = { workspace = true }
-prost             = { workspace = true }
+babylon-proto = { path = "../../packages/proto" }
+cosmwasm-vm   = { workspace = true }
+prost         = { workspace = true }

--- a/contracts/btc-staking/src/queries.rs
+++ b/contracts/btc-staking/src/queries.rs
@@ -272,7 +272,7 @@ mod tests {
     use cosmwasm_std::{from_json, Env, Storage};
 
     use babylon_apis::btc_staking_api::{FinalityProvider, UnbondedBtcDelegation};
-    use test_utils::{create_new_finality_provider, get_btc_del_unbonding_sig};
+    use babylon_test_utils::{create_new_finality_provider, get_btc_del_unbonding_sig};
 
     use crate::contract::{execute, instantiate};
     use crate::error::ContractError;
@@ -387,8 +387,8 @@ mod tests {
         let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
 
         // Add a couple delegations
-        let del1 = test_utils::get_derived_btc_delegation(1, &[1]);
-        let del2 = test_utils::get_derived_btc_delegation(2, &[2]);
+        let del1 = babylon_test_utils::get_derived_btc_delegation(1, &[1]);
+        let del2 = babylon_test_utils::get_derived_btc_delegation(2, &[2]);
 
         let msg = ExecuteMsg::BtcStaking {
             new_fp: vec![],
@@ -459,8 +459,8 @@ mod tests {
         let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
 
         // Add a couple delegations
-        let del1 = test_utils::get_derived_btc_delegation(1, &[1]);
-        let del2 = test_utils::get_derived_btc_delegation(2, &[1]);
+        let del1 = babylon_test_utils::get_derived_btc_delegation(1, &[1]);
+        let del2 = babylon_test_utils::get_derived_btc_delegation(2, &[1]);
 
         let msg = ExecuteMsg::BtcStaking {
             new_fp: vec![],
@@ -484,7 +484,7 @@ mod tests {
         // Unbond the second delegation
         // Compute staking tx hash
         let staking_tx_hash_hex = staking_tx_hash(&del2.into()).to_string();
-        let unbonding_sig = test_utils::get_btc_del_unbonding_sig(2, &[1]);
+        let unbonding_sig = babylon_test_utils::get_btc_del_unbonding_sig(2, &[1]);
         let msg = ExecuteMsg::BtcStaking {
             new_fp: vec![],
             active_del: vec![],
@@ -549,8 +549,8 @@ mod tests {
         let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
 
         // Add a couple delegations
-        let del1 = test_utils::get_derived_btc_delegation(1, &[1]);
-        let del2 = test_utils::get_derived_btc_delegation(2, &[2]);
+        let del1 = babylon_test_utils::get_derived_btc_delegation(1, &[1]);
+        let del2 = babylon_test_utils::get_derived_btc_delegation(2, &[2]);
 
         let msg = ExecuteMsg::BtcStaking {
             new_fp: vec![],
@@ -606,8 +606,8 @@ mod tests {
         let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
 
         // Add a couple delegations
-        let mut del1 = test_utils::get_derived_btc_delegation(1, &[1]);
-        let mut del2 = test_utils::get_derived_btc_delegation(2, &[1]);
+        let mut del1 = babylon_test_utils::get_derived_btc_delegation(1, &[1]);
+        let mut del2 = babylon_test_utils::get_derived_btc_delegation(2, &[1]);
 
         // Adjust staking amounts
         del1.total_sat = 100;
@@ -698,8 +698,8 @@ mod tests {
         let _res = execute(deps.as_mut(), initial_env, info.clone(), msg).unwrap();
 
         // Add a couple delegations
-        let mut del1 = test_utils::get_derived_btc_delegation(1, &[1]);
-        let mut del2 = test_utils::get_derived_btc_delegation(2, &[1]);
+        let mut del1 = babylon_test_utils::get_derived_btc_delegation(1, &[1]);
+        let mut del2 = babylon_test_utils::get_derived_btc_delegation(2, &[1]);
 
         // Adjust staking amounts
         del1.total_sat = 100;
@@ -801,7 +801,7 @@ mod tests {
         let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
 
         // Add a delegation
-        let mut del1 = test_utils::get_derived_btc_delegation(1, &[1]);
+        let mut del1 = babylon_test_utils::get_derived_btc_delegation(1, &[1]);
         // Adjust staking amount
         del1.total_sat = 100;
 
@@ -859,9 +859,9 @@ mod tests {
         let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
 
         // Add some delegations
-        let mut del1 = test_utils::get_derived_btc_delegation(1, &[1, 3]);
-        let mut del2 = test_utils::get_derived_btc_delegation(2, &[2]);
-        let mut del3 = test_utils::get_derived_btc_delegation(3, &[2]);
+        let mut del1 = babylon_test_utils::get_derived_btc_delegation(1, &[1, 3]);
+        let mut del2 = babylon_test_utils::get_derived_btc_delegation(2, &[2]);
+        let mut del3 = babylon_test_utils::get_derived_btc_delegation(3, &[2]);
 
         // Adjust staking amounts
         del1.total_sat = 100;

--- a/contracts/btc-staking/src/staking.rs
+++ b/contracts/btc-staking/src/staking.rs
@@ -731,7 +731,7 @@ pub(crate) mod tests {
 
     use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
 
-    use test_utils::{
+    use babylon_test_utils::{
         create_new_finality_provider, create_new_fp_sk, get_active_btc_delegation,
         get_btc_del_unbonding_sig, get_derived_btc_delegation,
     };

--- a/contracts/btc-staking/src/test_utils.rs
+++ b/contracts/btc-staking/src/test_utils.rs
@@ -1,5 +1,5 @@
 use babylon_bitcoin::chain_params::Network;
-use test_utils::get_params;
+use babylon_test_utils::get_params;
 
 use crate::state::config::Params;
 

--- a/packages/apis/Cargo.toml
+++ b/packages/apis/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "babylon-apis"
-version.workspace = true
+description = "Babylon APIs for BSN staking integration"
 edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
 
 [dependencies]
-babylon-bitcoin  = { path = "../bitcoin" }
-babylon-merkle   = { path = "../merkle" }
-babylon-proto    = { workspace = true }
+babylon-bitcoin  = { path = "../bitcoin", version = "0.14.0" }
+babylon-merkle   = { path = "../merkle", version = "0.14.0" }
+babylon-proto    = { path = "../proto", version = "0.14.0" }
 bech32           = { workspace = true }
 cosmwasm-std     = { workspace = true }
 cosmwasm-schema  = { workspace = true }

--- a/packages/bitcoin/Cargo.toml
+++ b/packages/bitcoin/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "babylon-bitcoin"
 description = "A wrapper of the rust-bitcoin library"
-version.workspace = true
 edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish           = true
 
 [dependencies]
 bitcoin      = { workspace = true }

--- a/packages/btcstaking/Cargo.toml
+++ b/packages/btcstaking/Cargo.toml
@@ -16,6 +16,6 @@ thiserror       = { workspace = true }
 eots            = { path = "../eots" }
 
 [dev-dependencies]
-test-utils    = { path = "../test-utils" }
-babylon-proto = { workspace = true }
-prost         = { workspace = true }
+babylon-proto      = { workspace = true }
+babylon-test-utils = { path = "../test-utils" }
+prost              = { workspace = true }

--- a/packages/btcstaking/src/tx_verify.rs
+++ b/packages/btcstaking/src/tx_verify.rs
@@ -201,7 +201,7 @@ mod tests {
     };
     use bitcoin::consensus::deserialize;
 
-    use test_utils::{get_btc_delegation, get_params};
+    use babylon_test_utils::{get_btc_delegation, get_params};
 
     #[test]
     fn test_check_transactions() {

--- a/packages/eots/Cargo.toml
+++ b/packages/eots/Cargo.toml
@@ -15,5 +15,5 @@ sha2        = { workspace = true }
 thiserror   = { workspace = true }
 
 [dev-dependencies]
-rand        = { workspace = true }
-test-utils  = { path = "../../packages/test-utils" }
+babylon-test-utils = { path = "../../packages/test-utils" }
+rand               = { workspace = true }

--- a/packages/eots/Cargo.toml
+++ b/packages/eots/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "eots"
+description = "EOTS (Extractable One Time Signature) utilities"
 edition.workspace = true
 version.workspace = true
 license.workspace = true

--- a/packages/eots/Cargo.toml
+++ b/packages/eots/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-publish.workspace = true
+publish           = true
 
 [dependencies]
 hex         = { workspace = true }

--- a/packages/eots/src/eots.rs
+++ b/packages/eots/src/eots.rs
@@ -357,9 +357,10 @@ mod tests {
     use super::*;
     use rand::{thread_rng, RngCore};
     use sha2::{Digest, Sha256};
-    use test_utils::get_eots_testdata;
 
     use k256::{ProjectivePoint, Scalar};
+
+    use babylon_test_utils::get_eots_testdata;
 
     pub fn rand_gen() -> (SecRand, PubRand) {
         let x = SecRand::new(&Scalar::generate_vartime(&mut thread_rng()).to_bytes()).unwrap();

--- a/packages/merkle/Cargo.toml
+++ b/packages/merkle/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "babylon-merkle"
 description = "CometBFT compatible Merkle proofs"
-version.workspace = true
 edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish           = true
 
 [dependencies]
 cosmwasm-schema  = { workspace = true }

--- a/packages/proto/Cargo.toml
+++ b/packages/proto/Cargo.toml
@@ -8,6 +8,8 @@ repository.workspace = true
 authors.workspace = true
 publish           = true
 
+exclude = [ "babylon" ]
+
 [lib]
 doctest = false
 

--- a/packages/proto/Cargo.toml
+++ b/packages/proto/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "babylon-proto"
-version.workspace = true
+description = "Babylon protobuf bindings"
 edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish           = true
 
 [lib]
 doctest = false

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
-name = "test-utils"
+name = "babylon-test-utils"
+description = "Utilities used in Babylon contracts tests"
 edition.workspace = true
 version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-publish.workspace = true
+publish           = true
 
 [dependencies]
 babylon-apis     = { path = "../apis" }

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -9,9 +9,9 @@ authors.workspace = true
 publish           = true
 
 [dependencies]
-babylon-apis     = { path = "../apis" }
-babylon-proto    = { path = "../proto" }
-babylon-bitcoin  = { path = "../bitcoin" }
+babylon-apis     = { path = "../apis", version = "0.14.0" }
+babylon-proto    = { path = "../proto", version = "0.14.0" }
+babylon-bitcoin  = { path = "../bitcoin", version = "0.14.0" }
 cosmwasm-std     = { workspace = true }
 hex              = { workspace = true }
 k256             = { workspace = true }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -14,9 +14,9 @@ then
 fi
 
 # These are imported by other packages - wait 30 seconds between each as they have linear dependencies
-BASE_CRATES=""
+BASE_CRATES="packages/bitcoin packages/eots packages/merkle packages/proto"
 
-ALL_CRATES="packages/eots packages/merkle packages/test-utils"
+ALL_CRATES="packages/apis packages/test-utils"
 
 SLEEP_TIME=30
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck >/dev/null && shellcheck "$0"
+
+function print_usage() {
+  echo "Usage: $0 [-h|--help]"
+  echo "Publishes crates to crates.io."
+}
+
+if [ $# = 1 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ] ; }
+then
+    print_usage
+    exit 1
+fi
+
+# These are imported by other packages - wait 30 seconds between each as they have linear dependencies
+BASE_CRATES=""
+
+ALL_CRATES="packages/eots packages/merkle packages/test-utils"
+
+SLEEP_TIME=30
+
+for CRATE in $BASE_CRATES; do
+  (
+    cd "$CRATE"
+    echo "Publishing $CRATE"
+    cargo publish
+    # wait for these to be processed on crates.io
+    echo "Waiting for crates.io to recognize $CRATE"
+    sleep $SLEEP_TIME
+  )
+done
+
+for CRATE in $ALL_CRATES; do
+  (
+    cd "$CRATE"
+    echo "Publishing $CRATE"
+    cargo publish
+  )
+done
+
+echo "Everything is published!"


### PR DESCRIPTION
Publish package crates to crates.io.

So that tehy can be used from other repos, i.e. rollup-bsn-contracts.