### PR TITLE
ci: add concurrency controls to GitHub workflows

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -1,4 +1,4 @@
-name: Bechmarking
+name: Benchmarking
 
 on:
   push:

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -1,11 +1,18 @@
 name: Bechmarking
+
 on:
   push:
     branches: [ "disabled" ]
   pull_request:
     branches: [ "disabled" ]
+
 env:
   CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmarking:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: Deployment
+
 on:
   push:
     tags:
@@ -6,6 +7,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
   WORKSPACE: "/home/runner/work/cosmos-bsn-contracts/cosmos-bsn-contracts"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_upload_contracts:
     runs-on: ubuntu-latest

--- a/.github/workflows/local-tests.yml
+++ b/.github/workflows/local-tests.yml
@@ -1,10 +1,16 @@
 name: Local Tests
+
 on:
   pull_request:
     branches:
       - '**'
 env:
   CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-schema-binary-naming:
     runs-on: ubuntu-latest

--- a/.github/workflows/wasm-tests-full.yml
+++ b/.github/workflows/wasm-tests-full.yml
@@ -1,4 +1,5 @@
 name: Full Tests
+
 on:
   pull_request:
     branches:
@@ -6,6 +7,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
   WORKSPACE: "/home/runner/work/cosmos-bsn-contracts/cosmos-bsn-contracts"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   wasm-build-check-integration-full:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add concurrency groups with `cancel-in-progress` to all workflows to prevent multiple runs of the same workflow on the same PR/branch, improving CI resource usage and reducing queue times.