### PR TITLE
chore: validate_slashing_tx in sync with Genesis

### DIFF
--- a/packages/btcstaking/src/error.rs
+++ b/packages/btcstaking/src/error.rs
@@ -46,8 +46,8 @@ pub enum Error {
     InsufficientSlashingAmount(u64),
     #[error("Slashing transaction must pay to the provided slashing pk script")]
     InvalidSlashingPkScript {},
-    #[error("Invalid slashing tx change output script")]
-    InvalidSlashingTxChangeOutputScript {},
+    #[error("Invalid slashing tx change output script, expected: {expected:?}, got: {actual:?}")]
+    InvalidSlashingTxChangeOutputScript { expected: Vec<u8>, actual: Vec<u8> },
     #[error("Transaction contains dust outputs")]
     TxContainsDustOutputs {},
     #[error("Slashing transaction fee must be larger than {0}")]
@@ -66,4 +66,6 @@ pub enum Error {
     InvalidTxVersion(i32, i32, i32),
     #[error("Pre-signed transaction must not have signature script")]
     TxHasSignatureScript {},
+    #[error("Slashing or staking transaction values must be larger than 0")]
+    InvalidSlashingAmount {},
 }

--- a/packages/btcstaking/src/tx_verify.rs
+++ b/packages/btcstaking/src/tx_verify.rs
@@ -14,13 +14,13 @@ const MAX_STANDARD_TX_WEIGHT: usize = 400000;
 /// This matches the maxTxVersion constant from Babylon Genesis.
 const MAX_TX_VERSION: i32 = 2;
 
-/// Checks if a script is an OP_RETURN output (matches Babylon Genesis isOPReturn function)
+/// Checks if a script is an OP_RETURN output
 fn is_op_return_output(script: &bitcoin::ScriptBuf) -> bool {
     let script_bytes = script.as_bytes();
     !script_bytes.is_empty() && script_bytes[0] == 0x6a // OP_RETURN opcode
 }
 
-/// Checks pre-signed transaction sanity (matches Babylon Genesis CheckPreSignedTxSanity)
+/// Checks pre-signed transaction sanity
 fn check_pre_signed_tx_sanity(
     tx: &Transaction,
     num_inputs: usize,
@@ -51,7 +51,7 @@ fn check_pre_signed_tx_sanity(
         ));
     }
 
-    // Check transaction weight (matches Babylon Genesis CheckPreSignedTxSanity)
+    // Check transaction weight
     let tx_weight = tx.weight().to_wu() as usize;
     if tx_weight > MAX_STANDARD_TX_WEIGHT {
         return Err(Error::TransactionWeightExceedsLimit(
@@ -163,7 +163,7 @@ fn validate_slashing_tx(
         });
     }
 
-    // Verify that none of the outputs is a dust output (matches Babylon Genesis logic)
+    // Verify that none of the outputs is a dust output
     for output in &slashing_tx.output {
         // OP_RETURN outputs can be dust and are considered standard (skip them like Babylon Genesis)
         if is_op_return_output(&output.script_pubkey) {
@@ -171,18 +171,17 @@ fn validate_slashing_tx(
         }
 
         // Use the standard dust threshold (546 satoshis for non-OP_RETURN outputs)
-        // This matches the behavior of mempool.IsDust() in Babylon Genesis
         if output.value.to_sat() <= 546 {
             return Err(Error::TxContainsDustOutputs {});
         }
     }
 
-    // Check that values of slashing and staking transaction are larger than 0 (matches Babylon Genesis)
+    // Check that values of slashing and staking transaction are larger than 0
     if slashing_tx.output[0].value.to_sat() == 0 || staking_output_value == 0 {
         return Err(Error::InvalidSlashingAmount {});
     }
 
-    // Check fees (matches Babylon Genesis logic)
+    // Check fees
     let total_output_value: u64 = slashing_tx
         .output
         .iter()

--- a/packages/btcstaking/src/tx_verify.rs
+++ b/packages/btcstaking/src/tx_verify.rs
@@ -2,10 +2,10 @@ use crate::error::Error;
 use crate::scripts_utils;
 use crate::Result;
 
+use bitcoin::opcodes::all::OP_RETURN;
 use bitcoin::Transaction;
 use k256::schnorr::VerifyingKey;
 use rust_decimal::{prelude::*, Decimal};
-use bitcoin::opcodes::all::OP_RETURN;
 
 /// Maximum transaction weight allowed in Babylon system.
 /// This matches the MaxStandardTxWeight constant from Babylon Genesis.


### PR DESCRIPTION
Depends on #192 

Aligns the `validate_slashing_tx` method with the Babylon Genesis one.