### PR TITLE
chore: remove `btc_light_client_initial_header`

### DIFF
--- a/contracts/babylon/src/error.rs
+++ b/contracts/babylon/src/error.rs
@@ -15,6 +15,8 @@ pub enum ContractError {
     InvalidReplyId(u64),
     #[error("The BTC header is empty")]
     BtcHeaderEmpty {},
+    #[error("BTC light client init message is missing")]
+    MissingBtcLightClientInitMsg,
     #[error("The BTC light client contract is not set")]
     BtcLightClientNotSet {},
     #[error("Missing base_header in the response of BTC light client contract instantiation")]

--- a/contracts/babylon/src/msg/contract.rs
+++ b/contracts/babylon/src/msg/contract.rs
@@ -32,8 +32,6 @@ pub struct InstantiateMsg {
     pub notify_cosmos_zone: bool,
     /// If set, this will instantiate a BTC light client contract
     pub btc_light_client_code_id: Option<u64>,
-    /// JSON encoded `InitialHeader` in hex.
-    pub btc_light_client_initial_header: String,
     /// If set, this will define the instantiation message for the BTC light client contract.
     /// This message is opaque to the Babylon contract, and depends on the specific light client
     /// being instantiated
@@ -72,7 +70,6 @@ impl InstantiateMsg {
             checkpoint_finalization_timeout: 1,
             notify_cosmos_zone: false,
             btc_light_client_code_id: None,
-            btc_light_client_initial_header: babylon_test_utils::initial_header_in_hex(),
             btc_light_client_msg: None,
             btc_staking_code_id: None,
             btc_staking_msg: None,

--- a/contracts/babylon/tests/integration.rs
+++ b/contracts/babylon/tests/integration.rs
@@ -62,7 +62,6 @@ fn instantiate_works() {
     let info = message_info(&Addr::unchecked(CREATOR), &[]);
     let res: ContractResult<Response> = instantiate(&mut deps, mock_env(), info, msg);
     let msgs = res.unwrap().messages;
-    println!("msgs: {msgs:?}");
     assert_eq!(0, msgs.len());
 }
 

--- a/contracts/babylon/tests/integration.rs
+++ b/contracts/babylon/tests/integration.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::testing::{message_info, mock_ibc_channel_open_try};
-use cosmwasm_std::{Addr, ContractResult, IbcOrder, Response};
+use cosmwasm_std::{to_json_binary, Addr, ContractResult, IbcOrder, Response};
 use cosmwasm_vm::testing::{
     ibc_channel_open, instantiate, mock_env, mock_instance, mock_instance_with_gas_limit, MockApi,
     MockQuerier, MockStorage,
@@ -8,6 +8,8 @@ use cosmwasm_vm::Instance;
 
 use babylon_contract::ibc::IBC_VERSION;
 use babylon_contract::msg::contract::InstantiateMsg;
+use btc_light_client::msg::InstantiateMsg as BtcLightClientInstantiateMsg;
+use btc_light_client::BitcoinNetwork;
 
 #[cfg(clippy)]
 static BABYLON_CONTRACT_WASM: &[u8] = &[];
@@ -26,6 +28,15 @@ fn setup() -> Instance<MockApi, MockStorage, MockQuerier> {
     let mut msg = InstantiateMsg::new_test();
     msg.btc_confirmation_depth = 10;
     msg.checkpoint_finalization_timeout = 99;
+    msg.btc_light_client_msg.replace(
+        to_json_binary(&BtcLightClientInstantiateMsg {
+            network: BitcoinNetwork::Testnet,
+            btc_confirmation_depth: 1,
+            checkpoint_finalization_timeout: 1,
+            initial_header: babylon_test_utils::initial_header(),
+        })
+        .unwrap(),
+    );
     let info = message_info(&Addr::unchecked(CREATOR), &[]);
     let res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();
     assert_eq!(0, res.messages.len());
@@ -51,6 +62,7 @@ fn instantiate_works() {
     let info = message_info(&Addr::unchecked(CREATOR), &[]);
     let res: ContractResult<Response> = instantiate(&mut deps, mock_env(), info, msg);
     let msgs = res.unwrap().messages;
+    println!("msgs: {msgs:?}");
     assert_eq!(0, msgs.len());
 }
 


### PR DESCRIPTION
@SebastianElvis was right that `btc_light_client_initial_header` is unnecessary as it's already contained in the `btc_light_client_msg`. See https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/176#discussion_r2215338173 for more info.