### PR TITLE
refactor:  simplify the full validation module

### DIFF
--- a/contracts/btc-staking/src/error.rs
+++ b/contracts/btc-staking/src/error.rs
@@ -114,6 +114,9 @@ pub enum ContractError {
     HexError(#[from] FromHexError),
     #[error(transparent)]
     SchnorrAdaptorSignature(#[from] babylon_schnorr_adaptor_signature::Error),
+    #[cfg(feature = "full-validation")]
+    #[error(transparent)]
+    FullValidation(#[from] crate::validation::FullValidationError),
 }
 
 impl From<bitcoin::consensus::encode::Error> for ContractError {

--- a/contracts/btc-staking/src/staking.rs
+++ b/contracts/btc-staking/src/staking.rs
@@ -76,7 +76,7 @@ pub fn handle_btc_staking(
 }
 
 /// Handles registering a new finality provider.
-pub fn handle_new_fp(
+fn handle_new_fp(
     storage: &mut dyn Storage,
     new_fp: &NewFinalityProvider,
     height: u64,
@@ -105,7 +105,7 @@ pub fn handle_new_fp(
     Ok(())
 }
 
-pub fn handle_active_delegation(
+fn handle_active_delegation(
     storage: &mut dyn Storage,
     height: u64,
     active_delegation: &ActiveBtcDelegation,

--- a/contracts/btc-staking/src/state/config.rs
+++ b/contracts/btc-staking/src/state/config.rs
@@ -47,3 +47,11 @@ pub struct Params {
     #[derivative(Default(value = "String::from(\"0.1\")"))]
     pub slashing_rate: String,
 }
+
+impl Params {
+    /// Check if the covenant public key is in the params.covenant_pks
+    #[cfg(feature = "full-validation")]
+    pub fn contains_covenant_pk(&self, pk: &k256::schnorr::VerifyingKey) -> bool {
+        self.covenant_pks.contains(&hex::encode(pk.to_bytes()))
+    }
+}

--- a/contracts/btc-staking/src/state/config.rs
+++ b/contracts/btc-staking/src/state/config.rs
@@ -54,4 +54,8 @@ impl Params {
     pub fn contains_covenant_pk(&self, pk: &k256::schnorr::VerifyingKey) -> bool {
         self.covenant_pks.contains(&hex::encode(pk.to_bytes()))
     }
+
+    pub fn slashing_rate(&self) -> Result<f64, std::num::ParseFloatError> {
+        self.slashing_rate.parse::<f64>()
+    }
 }

--- a/contracts/btc-staking/src/state/delegations.rs
+++ b/contracts/btc-staking/src/state/delegations.rs
@@ -4,6 +4,15 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{CanonicalAddr, Order, StdResult, Storage, Uint128};
 use cw_storage_plus::{Index, IndexList, IndexedMap, KeyDeserialize, MultiIndex};
 
+const DELEGATIONS_KEY: &str = "delegations";
+const FP_SUBKEY: &str = "fp";
+const STAKER_SUBKEY: &str = "staker";
+
+/// Indexed map for delegations and finality providers.
+pub fn delegations<'a>() -> Delegations<'a> {
+    Delegations::new(DELEGATIONS_KEY, FP_SUBKEY, STAKER_SUBKEY)
+}
+
 /// Single delegation related information - entry per `(staking hash, finality provider public key)`
 /// pair, including distribution alignment
 #[cw_serde]
@@ -143,13 +152,4 @@ impl Delegations<'_> {
             })
             .collect::<StdResult<Vec<(Vec<u8>, DelegationDistribution)>>>()
     }
-}
-
-const DELEGATIONS_KEY: &str = "delegations";
-const FP_SUBKEY: &str = "fp";
-const STAKER_SUBKEY: &str = "staker";
-
-/// Indexed map for delegations and finality providers.
-pub fn delegations<'a>() -> Delegations<'a> {
-    Delegations::new(DELEGATIONS_KEY, FP_SUBKEY, STAKER_SUBKEY)
 }

--- a/contracts/btc-staking/src/validation/full.rs
+++ b/contracts/btc-staking/src/validation/full.rs
@@ -58,7 +58,7 @@ fn decode_pks(
     Ok((staker_pk, fp_pks, cov_pks))
 }
 
-/// Verifies the new finality provider data (full validation version).
+/// Verifies the new finality provider data.
 pub fn verify_new_fp(new_fp: &NewFinalityProvider) -> Result<(), ContractError> {
     let fp_pk = verifying_key_from_hex(&new_fp.btc_pk_hex)?;
 

--- a/contracts/btc-staking/src/validation/full.rs
+++ b/contracts/btc-staking/src/validation/full.rs
@@ -254,13 +254,6 @@ pub fn verify_active_delegation(
     /*
         Check staker signature against slashing path of the unbonding tx
     */
-    let babylon_unbonding_script_paths = babylon_btcstaking::types::BabylonScriptPaths::new(
-        &staker_pk,
-        &fp_pks,
-        &cov_pks,
-        params.covenant_quorum as usize,
-        staking_time,
-    )?;
     // get the staker's signature on the unbonding slashing tx
     let unbonding_slashing_sig = active_delegation
         .undelegation_info
@@ -271,7 +264,7 @@ pub fn verify_active_delegation(
     babylon_btcstaking::staking::verify_transaction_sig_with_output(
         &unbonding_slashing_tx,
         &unbonding_tx.output[unbonding_output_idx as usize],
-        babylon_unbonding_script_paths.slashing_path_script(),
+        babylon_script_paths.slashing_path_script(),
         &staker_pk,
         &unbonding_slashing_sig,
     )?;
@@ -318,7 +311,7 @@ pub fn verify_active_delegation(
             enc_verify_transaction_sig_with_output(
                 &unbonding_slashing_tx,
                 unbonding_output,
-                babylon_unbonding_script_paths.slashing_path_script(),
+                babylon_script_paths.slashing_path_script(),
                 &cov_pk,
                 fp_pk,
                 &AdaptorSignature::new(sig.as_slice())?,

--- a/contracts/btc-staking/src/validation/full.rs
+++ b/contracts/btc-staking/src/validation/full.rs
@@ -24,7 +24,7 @@ pub enum FullValidationError {
     MissingProofOfPossession,
 
     #[error("Failed to parse slashing rate: {0}")]
-    InvalidSlashingRate(std::num::ParseFloatError),
+    InvalidSlashingRate(#[from] std::num::ParseFloatError),
 
     #[error("Unbonding transaction must spend staking output")]
     UnbondingTxMustSpendStakingOutput,
@@ -139,10 +139,7 @@ pub fn verify_active_delegation(
     let slashing_pk_script = hex::decode(&params.slashing_pk_script)?;
 
     // Check slashing tx and staking tx are valid and consistent
-    let slashing_rate = params
-        .slashing_rate
-        .parse::<f64>()
-        .map_err(FullValidationError::InvalidSlashingRate)?;
+    let slashing_rate = params.slashing_rate()?;
 
     babylon_btcstaking::staking::check_slashing_tx_match_funding_tx(
         &slashing_tx,

--- a/contracts/btc-staking/src/validation/full.rs
+++ b/contracts/btc-staking/src/validation/full.rs
@@ -259,11 +259,15 @@ pub fn verify_active_delegation(
         .delegator_slashing_sig
         .as_slice();
     let unbonding_slashing_sig = k256::schnorr::Signature::try_from(unbonding_slashing_sig)?;
+    // The unbonding slashing and regular slashing share the same script structure,
+    // the only difference is in the timelock value.
+    let unbonding_slashing_path_script = babylon_script_paths.slashing_path_script();
+
     // Verify the staker's signature
     babylon_btcstaking::staking::verify_transaction_sig_with_output(
         &unbonding_slashing_tx,
         &unbonding_tx.output[unbonding_output_idx as usize],
-        babylon_script_paths.slashing_path_script(),
+        unbonding_slashing_path_script,
         &staker_pk,
         &unbonding_slashing_sig,
     )?;
@@ -310,7 +314,7 @@ pub fn verify_active_delegation(
             enc_verify_transaction_sig_with_output(
                 &unbonding_slashing_tx,
                 unbonding_output,
-                babylon_script_paths.slashing_path_script(),
+                unbonding_slashing_path_script,
                 &cov_pk,
                 fp_pk,
                 &AdaptorSignature::new(sig.as_slice())?,

--- a/contracts/btc-staking/src/validation/full.rs
+++ b/contracts/btc-staking/src/validation/full.rs
@@ -188,19 +188,14 @@ pub fn verify_active_delegation(
                 "Covenant public key not found in params".to_string(),
             ));
         }
-        let sigs = cov_sig
-            .adaptor_sigs
-            .iter()
-            .map(|sig| AdaptorSignature::new(sig.as_slice()).map_err(Into::into))
-            .collect::<Result<Vec<AdaptorSignature>, ContractError>>()?;
-        for (sig, fp_pk) in sigs.iter().zip(fp_pks.iter()) {
+        for (sig, fp_pk) in cov_sig.adaptor_sigs.iter().zip(fp_pks.iter()) {
             enc_verify_transaction_sig_with_output(
                 &slashing_tx,
                 staking_output,
                 slashing_path_script.as_script(),
                 &cov_pk,
                 fp_pk,
-                sig,
+                &AdaptorSignature::new(sig.as_slice())?,
             )?;
         }
     }

--- a/contracts/btc-staking/src/validation/full.rs
+++ b/contracts/btc-staking/src/validation/full.rs
@@ -40,8 +40,7 @@ fn verify_pop(
     pop: &ProofOfPossessionBtc,
 ) -> Result<(), ContractError> {
     // get signed msg, i.e., the hash of the canonicalised address
-    let address_bytes = address.as_slice();
-    let msg_hash: [u8; 32] = Sha256::new_with_prefix(address_bytes).finalize().into();
+    let msg_hash: [u8; 32] = Sha256::digest(address.as_slice()).into();
 
     // verify PoP
     let btc_sig_type =

--- a/contracts/btc-staking/src/validation/full.rs
+++ b/contracts/btc-staking/src/validation/full.rs
@@ -326,19 +326,14 @@ pub fn verify_active_delegation(
         if !params.contains_covenant_pk(&cov_pk) {
             return Err(FullValidationError::MissingCovenantPublicKeyInParams.into());
         }
-        let sigs = cov_sig
-            .adaptor_sigs
-            .iter()
-            .map(|sig| AdaptorSignature::new(sig.as_slice()).map_err(Into::into))
-            .collect::<Result<Vec<AdaptorSignature>, ContractError>>()?;
-        for (idx, sig) in sigs.iter().enumerate() {
+        for (sig, fp_pk) in cov_sig.adaptor_sigs.iter().zip(fp_pks.iter()) {
             enc_verify_transaction_sig_with_output(
                 &unbonding_slashing_tx,
                 unbonding_output,
                 unbonding_slashing_path_script.as_script(),
                 &cov_pk,
-                &fp_pks[idx],
-                sig,
+                fp_pk,
+                &AdaptorSignature::new(sig.as_slice())?,
             )?;
         }
     }

--- a/contracts/btc-staking/src/validation/full.rs
+++ b/contracts/btc-staking/src/validation/full.rs
@@ -139,7 +139,9 @@ pub fn verify_active_delegation(
     let slashing_pk_script = hex::decode(&params.slashing_pk_script)?;
 
     // Check slashing tx and staking tx are valid and consistent
-    let slashing_rate = params.slashing_rate()?;
+    let slashing_rate = params
+        .slashing_rate()
+        .map_err(FullValidationError::InvalidSlashingRate)?;
 
     babylon_btcstaking::staking::check_slashing_tx_match_funding_tx(
         &slashing_tx,
@@ -269,7 +271,7 @@ pub fn verify_active_delegation(
     /*
         verify covenant signatures over unbonding tx
     */
-    let unbonding_path_script = babylon_script_paths.unbonding_path_script;
+    let unbonding_path_script = babylon_script_paths.unbonding_path_script.as_script();
     for cov_sig in active_delegation
         .undelegation_info
         .covenant_unbonding_sig_list
@@ -286,7 +288,7 @@ pub fn verify_active_delegation(
         babylon_btcstaking::staking::verify_transaction_sig_with_output(
             staking_tx,
             staking_output,
-            unbonding_path_script.as_script(),
+            unbonding_path_script,
             &cov_pk,
             &sig,
         )?;

--- a/contracts/btc-staking/src/validation/mod.rs
+++ b/contracts/btc-staking/src/validation/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "full-validation")]
 mod full;
 
+#[cfg(feature = "full-validation")]
+pub use self::full::FullValidationError;
 use crate::state::config::Params;
 use crate::{error::ContractError, state::staking::BtcDelegation};
 use babylon_apis::btc_staking_api::{ActiveBtcDelegation, NewFinalityProvider};

--- a/packages/btcstaking/src/types.rs
+++ b/packages/btcstaking/src/types.rs
@@ -5,7 +5,7 @@ use bitcoin::opcodes::all::OP_PUSHNUM_1;
 
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::taproot::LeafVersion;
-use bitcoin::ScriptBuf;
+use bitcoin::{Script, ScriptBuf};
 use bitcoin::{TapNodeHash, TapTweakHash, XOnlyPublicKey};
 
 use rust_decimal::{prelude::*, Decimal};
@@ -172,6 +172,10 @@ impl BabylonScriptPaths {
             unbonding_path_script,
             slashing_path_script,
         })
+    }
+
+    pub fn slashing_path_script(&self) -> &Script {
+        &self.slashing_path_script
     }
 
     // TODO: implement a function for aggregating all scripts to a single ScriptBuf


### PR DESCRIPTION
This PR refactors the full validation logic to improve readability and efficiency ahead of #7. Review by commit is recommended.

Notably, [a12edcb](https://github.com/babylonlabs-io/cosmos-bsn-contracts/commit/a12edcb1cc64396680a4907b58a60c532fbb2d7d) might need a second look — unsure if the original logic was intentional.

Most changes are straightforward, but let me know if anything looks off.