### PR TITLE
chore: release 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "babylon-apis"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "babylon-merkle",
  "babylon-proto",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "babylon-btcstaking"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "babylon-proto",
  "babylon-schnorr-adaptor-signature",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "babylon-contract"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "babylon-merkle"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "babylon-proto"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bitvec",
  "cosmos-sdk-proto 0.27.0",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "babylon-schnorr-adaptor-signature"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "digest",
  "k256",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "babylon-test-utils"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "babylon-apis",
  "babylon-proto",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "btc-finality"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anybuf",
  "anyhow",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "btc-light-client"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "btc-staking"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "babylon-apis",
  "babylon-bindings",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "eots"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "babylon-test-utils",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition    = "2021"
-version    = "0.15.0"
+version    = "0.15.1"
 license    = "Apache-2.0"
 repository = "https://github.com/babylonlabs-io/cosmos-bsn-contracts"
 authors    = ["Babylon Labs Ltd. <admin@babylonlabs.io>"]

--- a/contracts/babylon/schema/babylon-contract.json
+++ b/contracts/babylon/schema/babylon-contract.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "babylon-contract",
-  "contract_version": "0.15.0",
+  "contract_version": "0.15.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -717,15 +717,21 @@
           ]
         },
         "btc_light_client": {
-          "description": "If set, this stores a BTC light client contract used for BTC light client on the Consumer",
-          "anyOf": [
+          "description": "If set, this stores the config for BTC light client contract on the Consumer.\n\nThis consists of a tuple: `(btc_light_client_address, encoded_btc_base_header)`, where: - `btc_light_client_address` is the address of the BTC light client contract. - `encoded_btc_base_header` is the encoded base Bitcoin header to initialize the light client.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": [
             {
               "$ref": "#/definitions/Addr"
             },
             {
-              "type": "null"
+              "$ref": "#/definitions/Binary"
             }
-          ]
+          ],
+          "maxItems": 2,
+          "minItems": 2
         },
         "btc_staking": {
           "description": "If set, this stores a BTC staking contract used for BTC re-staking",
@@ -772,6 +778,10 @@
       "definitions": {
         "Addr": {
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
           "type": "string"
         },
         "BitcoinNetwork": {

--- a/contracts/babylon/schema/raw/response_to_config.json
+++ b/contracts/babylon/schema/raw/response_to_config.json
@@ -36,15 +36,21 @@
       ]
     },
     "btc_light_client": {
-      "description": "If set, this stores a BTC light client contract used for BTC light client on the Consumer",
-      "anyOf": [
+      "description": "If set, this stores the config for BTC light client contract on the Consumer.\n\nThis consists of a tuple: `(btc_light_client_address, encoded_btc_base_header)`, where: - `btc_light_client_address` is the address of the BTC light client contract. - `encoded_btc_base_header` is the encoded base Bitcoin header to initialize the light client.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": [
         {
           "$ref": "#/definitions/Addr"
         },
         {
-          "type": "null"
+          "$ref": "#/definitions/Binary"
         }
-      ]
+      ],
+      "maxItems": 2,
+      "minItems": 2
     },
     "btc_staking": {
       "description": "If set, this stores a BTC staking contract used for BTC re-staking",
@@ -91,6 +97,10 @@
   "definitions": {
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
     },
     "BitcoinNetwork": {

--- a/contracts/btc-finality/schema/btc-finality.json
+++ b/contracts/btc-finality/schema/btc-finality.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "btc-finality",
-  "contract_version": "0.15.0",
+  "contract_version": "0.15.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/btc-light-client/schema/btc-light-client.json
+++ b/contracts/btc-light-client/schema/btc-light-client.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "btc-light-client",
-  "contract_version": "0.15.0",
+  "contract_version": "0.15.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/btc-staking/schema/btc-staking.json
+++ b/contracts/btc-staking/schema/btc-staking.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "btc-staking",
-  "contract_version": "0.15.0",
+  "contract_version": "0.15.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
Only to include patches for fixing the base header and the schema generation in the release process.