### PR TITLE
refactor(btc-light-client): Improve header processing and code quality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
 name = "babylon-proto"
 version = "0.15.1"
 dependencies = [
+ "bitcoin",
  "bitvec",
  "cosmos-sdk-proto 0.27.0",
  "pbjson-types",

--- a/contracts/babylon/src/contract.rs
+++ b/contracts/babylon/src/contract.rs
@@ -334,7 +334,7 @@ pub fn execute(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use babylon_test_utils::get_btc_initial_header;
+    use babylon_test_utils::get_btc_base_header;
     use bitcoin::block::Header as BlockHeader;
     use btc_light_client::msg::InstantiateMsg as BtcLightClientInstantiateMsg;
     use cosmwasm_std::testing::message_info;
@@ -370,7 +370,7 @@ mod tests {
             network: btc_light_client::BitcoinNetwork::Regtest,
             btc_confirmation_depth: msg.btc_confirmation_depth,
             checkpoint_finalization_timeout: msg.checkpoint_finalization_timeout,
-            initial_header: get_btc_initial_header(),
+            base_header: get_btc_base_header(),
         };
 
         msg.btc_light_client_msg

--- a/contracts/babylon/src/multitest.rs
+++ b/contracts/babylon/src/multitest.rs
@@ -84,7 +84,7 @@ mod instantiation {
             network: btc_light_client::BitcoinNetwork::Regtest,
             btc_confirmation_depth: 1,
             checkpoint_finalization_timeout: 1,
-            initial_header: babylon_test_utils::get_btc_initial_header(),
+            base_header: babylon_test_utils::get_btc_base_header(),
         };
         let suite = SuiteBuilder::new()
             .with_light_client_msg(&to_json_string(&params).unwrap())

--- a/contracts/babylon/src/multitest/suite.rs
+++ b/contracts/babylon/src/multitest/suite.rs
@@ -131,7 +131,7 @@ impl SuiteBuilder {
                     network: BitcoinNetwork::Testnet,
                     btc_confirmation_depth: 1,
                     checkpoint_finalization_timeout,
-                    initial_header: babylon_test_utils::get_btc_initial_header(),
+                    base_header: babylon_test_utils::get_btc_base_header(),
                 };
 
                 to_json_binary(&btc_lc_init_msg).unwrap()

--- a/contracts/babylon/tests/integration.rs
+++ b/contracts/babylon/tests/integration.rs
@@ -33,7 +33,7 @@ fn setup() -> Instance<MockApi, MockStorage, MockQuerier> {
             network: BitcoinNetwork::Testnet,
             btc_confirmation_depth: 1,
             checkpoint_finalization_timeout: 1,
-            initial_header: babylon_test_utils::get_btc_initial_header(),
+            base_header: babylon_test_utils::get_btc_base_header(),
         })
         .unwrap(),
     );

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -124,7 +124,7 @@ impl SuiteBuilder {
                 network: BitcoinNetwork::Testnet,
                 btc_confirmation_depth: 1,
                 checkpoint_finalization_timeout: 1,
-                initial_header: babylon_test_utils::get_btc_initial_header(),
+                base_header: babylon_test_utils::get_btc_base_header(),
             };
 
             to_json_binary(&btc_lc_init_msg).unwrap()

--- a/contracts/btc-light-client/benches/main.rs
+++ b/contracts/btc-light-client/benches/main.rs
@@ -16,7 +16,7 @@ use cosmwasm_vm::testing::{
 use cosmwasm_vm::Instance;
 
 use babylon_bindings::BabylonMsg;
-use babylon_test_utils::{btc_initial_header, get_btc_lc_mainchain_resp};
+use babylon_test_utils::{btc_base_header, get_btc_lc_mainchain_resp};
 use btc_light_client::msg::btc_header::BtcHeader;
 use btc_light_client::msg::contract::{ExecuteMsg, InstantiateMsg};
 
@@ -49,7 +49,7 @@ pub fn setup_instance() -> Instance<MockApi, MockStorage, MockQuerier> {
         network: btc_light_client::BitcoinNetwork::Regtest,
         btc_confirmation_depth: 10,
         checkpoint_finalization_timeout: 2,
-        initial_header: Some(btc_initial_header()),
+        base_header: Some(btc_base_header()),
     };
     let info = mock_info(CREATOR, &[]);
     let res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();

--- a/contracts/btc-light-client/schema/btc-light-client.json
+++ b/contracts/btc-light-client/schema/btc-light-client.json
@@ -12,6 +12,17 @@
       "network"
     ],
     "properties": {
+      "base_header": {
+        "description": "Initial BTC header. If not provided, the light client will rely on and trust Babylon's provided initial header",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/BaseHeader"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "btc_confirmation_depth": {
         "type": "integer",
         "format": "uint32",
@@ -22,23 +33,45 @@
         "format": "uint32",
         "minimum": 0.0
       },
-      "initial_header": {
-        "description": "Initial BTC header. If not provided, the light client will rely on and trust Babylon's provided initial header",
-        "anyOf": [
-          {
-            "$ref": "#/definitions/InitialHeader"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
       "network": {
         "$ref": "#/definitions/BitcoinNetwork"
       }
     },
     "additionalProperties": false,
     "definitions": {
+      "BaseHeader": {
+        "type": "object",
+        "required": [
+          "header",
+          "height",
+          "total_work"
+        ],
+        "properties": {
+          "header": {
+            "description": "Initial BTC header to initialize the light client.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/BtcHeader"
+              }
+            ]
+          },
+          "height": {
+            "description": "Height of the initial header.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "total_work": {
+            "description": "Total accumulated work of the initial header, encoded as big-endian bytes.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
@@ -93,39 +126,6 @@
             "description": "Originally protocol version, but repurposed for soft-fork signaling.\n\n### Relevant BIPs\n\n* [BIP9 - Version bits with timeout and delay](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki) (current usage) * [BIP34 - Block v2, Height in Coinbase](https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki)",
             "type": "integer",
             "format": "int32"
-          }
-        },
-        "additionalProperties": false
-      },
-      "InitialHeader": {
-        "type": "object",
-        "required": [
-          "header",
-          "height",
-          "total_work"
-        ],
-        "properties": {
-          "header": {
-            "description": "Initial BTC header to initialize the light client.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/BtcHeader"
-              }
-            ]
-          },
-          "height": {
-            "description": "Height of the initial header.",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "total_work": {
-            "description": "Total accumulated work of the initial header, encoded as big-endian bytes.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Binary"
-              }
-            ]
           }
         },
         "additionalProperties": false

--- a/contracts/btc-light-client/schema/raw/instantiate.json
+++ b/contracts/btc-light-client/schema/raw/instantiate.json
@@ -8,6 +8,17 @@
     "network"
   ],
   "properties": {
+    "base_header": {
+      "description": "Initial BTC header. If not provided, the light client will rely on and trust Babylon's provided initial header",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/BaseHeader"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "btc_confirmation_depth": {
       "type": "integer",
       "format": "uint32",
@@ -18,23 +29,45 @@
       "format": "uint32",
       "minimum": 0.0
     },
-    "initial_header": {
-      "description": "Initial BTC header. If not provided, the light client will rely on and trust Babylon's provided initial header",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/InitialHeader"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "network": {
       "$ref": "#/definitions/BitcoinNetwork"
     }
   },
   "additionalProperties": false,
   "definitions": {
+    "BaseHeader": {
+      "type": "object",
+      "required": [
+        "header",
+        "height",
+        "total_work"
+      ],
+      "properties": {
+        "header": {
+          "description": "Initial BTC header to initialize the light client.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BtcHeader"
+            }
+          ]
+        },
+        "height": {
+          "description": "Height of the initial header.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "total_work": {
+          "description": "Total accumulated work of the initial header, encoded as big-endian bytes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Binary"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
@@ -89,39 +122,6 @@
           "description": "Originally protocol version, but repurposed for soft-fork signaling.\n\n### Relevant BIPs\n\n* [BIP9 - Version bits with timeout and delay](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki) (current usage) * [BIP34 - Block v2, Height in Coinbase](https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki)",
           "type": "integer",
           "format": "int32"
-        }
-      },
-      "additionalProperties": false
-    },
-    "InitialHeader": {
-      "type": "object",
-      "required": [
-        "header",
-        "height",
-        "total_work"
-      ],
-      "properties": {
-        "header": {
-          "description": "Initial BTC header to initialize the light client.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/BtcHeader"
-            }
-          ]
-        },
-        "height": {
-          "description": "Height of the initial header.",
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
-        },
-        "total_work": {
-          "description": "Total accumulated work of the initial header, encoded as big-endian bytes.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Binary"
-            }
-          ]
         }
       },
       "additionalProperties": false

--- a/contracts/btc-light-client/src/bitcoin.rs
+++ b/contracts/btc-light-client/src/bitcoin.rs
@@ -90,8 +90,8 @@ pub fn verify_headers(
     let mut pending_headers = BTreeMap::new();
 
     for (i, new_header) in new_headers.iter().enumerate() {
-        let prev_block_header: BlockHeader = deserialize(last_header.header.as_ref())?;
-        let block_header: BlockHeader = deserialize(new_header.header.as_ref())?;
+        let prev_block_header = last_header.block_header()?;
+        let block_header = new_header.block_header()?;
 
         // Check whether the headers form a chain.
         if block_header.prev_blockhash != prev_block_header.block_hash() {
@@ -293,8 +293,7 @@ fn get_next_work_required(
         let last_retarget_height = height - difficulty_adjustment_interval;
 
         let retarget_header_info = get_header(storage, last_retarget_height)?;
-        let retarget_header: BlockHeader =
-            bitcoin::consensus::deserialize(&retarget_header_info.header)?;
+        let retarget_header = retarget_header_info.block_header()?;
 
         let first_block_time = retarget_header.time;
 
@@ -484,15 +483,14 @@ mod tests {
         ];
         init_contract(&mut storage, &initial_headers).unwrap();
 
-        let prev_header: BlockHeader =
-            deserialize(test_headers[3].clone().header.as_ref()).unwrap();
+        let prev_header = test_headers[3].block_header().unwrap();
 
         // Use as many previous headers as available if there are fewer than 11.
         let mtp = calculate_median_time_past(&storage, &prev_header, &Default::default()).unwrap();
 
         let times = initial_headers
             .iter()
-            .map(|h| deserialize::<BlockHeader>(h.header.as_ref()).unwrap().time)
+            .map(|h| h.block_header().unwrap().time)
             .collect::<Vec<_>>();
 
         assert_eq!(mtp, expected_median(times));

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -152,9 +152,10 @@ fn init_btc_headers(
 
     // ensure there are >=w+1 headers, i.e. a base header and at least w subsequent
     // ones as a w-deep proof
-    if (headers.len() as u32) < cfg.checkpoint_finalization_timeout + 1 {
+    let min_required_headers = cfg.checkpoint_finalization_timeout + 1;
+    if (headers.len() as u32) < min_required_headers {
         return Err(
-            InitHeadersError::NotEnoughHeaders(cfg.checkpoint_finalization_timeout + 1).into(),
+            InitHeadersError::InsufficientHeaders(min_required_headers, headers.len()).into(),
         );
     }
 

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -83,19 +83,14 @@ pub fn execute(
         } => {
             let api = deps.api;
             let headers_len = headers.len();
-            let resp = match handle_btc_headers(deps, headers, first_work, first_height) {
-                Ok(resp) => {
-                    api.debug(&format!("Successfully handled {headers_len} BTC headers"));
-                    resp
-                }
-                Err(e) => {
-                    let err = format!("Failed to handle {headers_len} BTC headers: {e}");
-                    api.debug(&err);
-                    return Err(e);
-                }
-            };
 
-            Ok(resp)
+            handle_btc_headers(deps, headers, first_work, first_height)
+                .inspect(|_| {
+                    api.debug(&format!("Successfully handled {headers_len} BTC headers"));
+                })
+                .inspect_err(|e| {
+                    api.debug(&format!("Failed to handle {headers_len} BTC headers: {e}"));
+                })
         }
     }
 }

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -131,7 +131,7 @@ fn handle_btc_headers(
         let first_work_bytes = hex::decode(first_work_hex)?;
         let first_work = total_work(&first_work_bytes)?;
 
-        init_btc_headers(deps.storage, &headers, &first_work, first_height)?;
+        init_btc_headers(deps.storage, &headers, first_work, first_height)?;
         Ok(Response::new().add_attribute("action", "init_btc_light_client"))
     } else {
         extend_btc_headers(deps.storage, &headers)?;
@@ -145,7 +145,7 @@ fn handle_btc_headers(
 fn init_btc_headers(
     storage: &mut dyn Storage,
     headers: &[BtcHeader],
-    first_work: &bitcoin::Work,
+    first_work: bitcoin::Work,
     first_height: u32,
 ) -> Result<(), ContractError> {
     let cfg = CONFIG.load(storage)?;
@@ -163,7 +163,7 @@ fn init_btc_headers(
 
     // base header is the first header in the list
     let base_header = headers.first().ok_or(InitHeadersError::MissingTipHeader)?;
-    let base_header = base_header.to_btc_header_info(first_height, *first_work)?;
+    let base_header = base_header.to_btc_header_info(first_height, first_work)?;
 
     // We need to initialize the base header (immutable) ahead of the subsequent headers
     // processing as `verify_headers` assumes the base header must already exist.

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -33,7 +33,7 @@ pub fn instantiate(
         network,
         btc_confirmation_depth,
         checkpoint_finalization_timeout,
-        initial_header,
+        base_header: maybe_base_header,
     } = msg;
 
     let cfg = Config {
@@ -44,8 +44,8 @@ pub fn instantiate(
 
     let mut res = Response::new();
 
-    // Initialises the BTC header chain storage if initial_header is provided.
-    if let Some(header) = initial_header {
+    // Initialises the BTC header chain storage if base header is provided.
+    if let Some(header) = maybe_base_header {
         let base_header = header.to_btc_header_info()?;
         let base_btc_header: BlockHeader =
             bitcoin::consensus::deserialize(base_header.header.as_ref())?;

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -35,24 +35,24 @@ pub fn instantiate(
         base_header: maybe_base_header,
     } = msg;
 
-    let cfg = Config {
-        network,
-        btc_confirmation_depth,
-        checkpoint_finalization_timeout,
-    };
-
     let mut res = Response::new();
 
     // Initialises the BTC header chain storage if base header is provided.
     if let Some(header) = maybe_base_header {
         let base_header_info = header.to_btc_header_info()?;
         let base_btc_header = base_header_info.block_header()?;
-        crate::bitcoin::check_proof_of_work(&cfg.network.chain_params(), &base_btc_header)?;
+        crate::bitcoin::check_proof_of_work(&network.chain_params(), &base_btc_header)?;
         // Store base header (immutable) and tip.
         set_base_header(deps.storage, &base_header_info)?;
         set_tip(deps.storage, &base_header_info)?;
         res = res.set_data(Binary::from(base_header_info.encode_to_vec()));
     }
+
+    let cfg = Config {
+        network,
+        btc_confirmation_depth,
+        checkpoint_finalization_timeout,
+    };
 
     CONFIG.save(deps.storage, &cfg)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -32,13 +32,13 @@ pub fn instantiate(
         network,
         btc_confirmation_depth,
         checkpoint_finalization_timeout,
-        base_header: maybe_base_header,
+        base_header,
     } = msg;
 
     let mut res = Response::new();
 
     // Initialises the BTC header chain storage if base header is provided.
-    if let Some(header) = maybe_base_header {
+    if let Some(header) = base_header {
         let base_header_info = header.to_btc_header_info()?;
         let base_btc_header = base_header_info.block_header()?;
         crate::bitcoin::check_proof_of_work(&network.chain_params(), &base_btc_header)?;
@@ -227,7 +227,6 @@ fn extend_btc_headers(
         previous_header.work.as_ref(),
     )?;
 
-    // Call `handle_btc_headers_from_babylon`
     handle_btc_headers_from_babylon(storage, &new_headers_info)
 }
 
@@ -244,7 +243,7 @@ fn extend_btc_headers(
 ///   as Babylon.
 ///
 /// Ref https://github.com/babylonlabs-io/babylon/blob/d3d81178dc38c172edaf5651c72b296bb9371a48/x/btclightclient/types/btc_light_client.go#L339
-pub fn handle_btc_headers_from_babylon(
+pub(crate) fn handle_btc_headers_from_babylon(
     storage: &mut dyn Storage,
     new_headers: &[BtcHeaderInfo],
 ) -> Result<(), ContractError> {

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -159,8 +159,6 @@ fn init_btc_headers(
         );
     }
 
-    let chain_params = cfg.network.chain_params();
-
     // base header is the first header in the list
     let base_header = headers.first().ok_or(InitHeadersError::MissingTipHeader)?;
     let base_header = base_header.to_btc_header_info(first_height, first_work)?;
@@ -169,14 +167,15 @@ fn init_btc_headers(
     // processing as `verify_headers` assumes the base header must already exist.
     set_base_header(storage, &base_header)?;
 
-    let subsequent_headers =
+    let new_headers =
         convert_to_btc_header_info(&headers[1..], base_header.height, &base_header.work)?;
 
     // Verify subsequent headers
-    verify_headers(storage, &chain_params, &base_header, &subsequent_headers)?;
+    let chain_params = cfg.network.chain_params();
+    verify_headers(storage, &chain_params, &base_header, &new_headers)?;
 
-    insert_headers(storage, &subsequent_headers)?;
-    let tip = subsequent_headers.last().unwrap_or(&base_header);
+    insert_headers(storage, &new_headers)?;
+    let tip = new_headers.last().unwrap_or(&base_header);
     set_tip(storage, tip)?;
 
     Ok(())

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -160,7 +160,10 @@ fn init_btc_headers(
     }
 
     // base header is the first header in the list
-    let base_header = headers.first().ok_or(InitHeadersError::MissingTipHeader)?;
+    let (base_header, new_headers) = headers
+        .split_first()
+        .expect("Headers must not be empty as checked above");
+
     let base_header = base_header.to_btc_header_info(first_height, first_work)?;
 
     // We need to initialize the base header (immutable) ahead of the subsequent headers
@@ -168,7 +171,7 @@ fn init_btc_headers(
     set_base_header(storage, &base_header)?;
 
     let new_headers =
-        convert_to_btc_header_info(&headers[1..], base_header.height, &base_header.work)?;
+        convert_to_btc_header_info(new_headers, base_header.height, &base_header.work)?;
 
     // Verify subsequent headers
     let chain_params = cfg.network.chain_params();

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -60,15 +60,6 @@ pub fn instantiate(
     Ok(res.add_attribute("action", "instantiate"))
 }
 
-pub fn migrate(
-    deps: DepsMut,
-    _env: Env,
-    _msg: Empty,
-) -> Result<Response<BabylonMsg>, ContractError> {
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    Ok(Response::new().add_attribute("action", "migrate"))
-}
-
 pub fn execute(
     deps: DepsMut,
     _env: Env,
@@ -115,6 +106,15 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
             reverse,
         )?)?),
     }
+}
+
+pub fn migrate(
+    deps: DepsMut,
+    _env: Env,
+    _msg: Empty,
+) -> Result<Response<BabylonMsg>, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::new().add_attribute("action", "migrate"))
 }
 
 fn handle_btc_headers(

--- a/contracts/btc-light-client/src/error.rs
+++ b/contracts/btc-light-client/src/error.rs
@@ -12,8 +12,6 @@ pub enum InitHeadersError {
     MissingBaseWork,
     #[error("Missing base height during initialization")]
     MissingBaseHeight,
-    #[error("Missing tip header")]
-    MissingTipHeader,
     #[error("Insufficient headers provided (required {0}, got: {1})")]
     InsufficientHeaders(u32, usize),
 }

--- a/contracts/btc-light-client/src/error.rs
+++ b/contracts/btc-light-client/src/error.rs
@@ -14,8 +14,8 @@ pub enum InitHeadersError {
     MissingBaseHeight,
     #[error("Missing tip header")]
     MissingTipHeader,
-    #[error("Not enough headers (expected at least {0})")]
-    NotEnoughHeaders(u32),
+    #[error("Insufficient headers provided (required {0}, got: {1})")]
+    InsufficientHeaders(u32, usize),
 }
 
 #[derive(Error, Debug, PartialEq)]

--- a/contracts/btc-light-client/src/msg/btc_header.rs
+++ b/contracts/btc-light-client/src/msg/btc_header.rs
@@ -82,7 +82,7 @@ impl BtcHeader {
 impl TryFrom<&BtcHeaderInfo> for BtcHeader {
     type Error = ContractError;
     fn try_from(btc_header_info: &BtcHeaderInfo) -> Result<Self, Self::Error> {
-        let block_header: BlockHeader = bitcoin::consensus::deserialize(&btc_header_info.header)?;
+        let block_header = btc_header_info.block_header()?;
         Ok(Self {
             version: block_header.version.to_consensus(),
             prev_blockhash: block_header.prev_blockhash.to_string(),

--- a/contracts/btc-light-client/src/tests.rs
+++ b/contracts/btc-light-client/src/tests.rs
@@ -7,7 +7,6 @@ use crate::ContractError;
 use crate::{BitcoinNetwork, ExecuteMsg};
 use babylon_proto::babylon::btclightclient::v1::BtcHeaderInfo;
 use bitcoin::block::Header as BlockHeader;
-use bitcoin::consensus::deserialize;
 use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
 use prost::Message;
 
@@ -88,7 +87,7 @@ fn instantiate_should_work() {
 
     // Submit new headers should work only if we have an initial header
     if get_btc_base_header().is_some() {
-        let new_header: BlockHeader = deserialize(&headers[1].header).unwrap();
+        let new_header = headers[1].block_header().unwrap();
         let msg = ExecuteMsg::BtcHeaders {
             headers: vec![new_header.into()],
             first_work: None,

--- a/contracts/btc-light-client/src/tests.rs
+++ b/contracts/btc-light-client/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::contract::{execute, instantiate};
-use crate::msg::contract::InitialHeader;
+use crate::msg::contract::BaseHeader;
 use crate::msg::InstantiateMsg;
 use crate::state::{get_tip, BTC_HEADERS, BTC_HEIGHTS, CONFIG};
 #[cfg(feature = "full-validation")]
@@ -12,7 +12,7 @@ use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
 use prost::Message;
 
 /// Helper function to get the appropriate initial header value based on the full-validation feature
-fn get_btc_initial_header() -> Option<InitialHeader> {
+fn get_btc_base_header() -> Option<BaseHeader> {
     #[cfg(feature = "full-validation")]
     {
         let headers = test_headers();
@@ -59,7 +59,7 @@ fn instantiate_should_work() {
         network: BitcoinNetwork::Mainnet,
         btc_confirmation_depth: 6,
         checkpoint_finalization_timeout: 100,
-        initial_header: get_btc_initial_header(),
+        base_header: get_btc_base_header(),
     };
 
     let res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -74,20 +74,20 @@ fn instantiate_should_work() {
     assert_eq!(cfg.checkpoint_finalization_timeout, 100);
     assert_eq!(cfg.network, BitcoinNetwork::Mainnet);
 
-    // Test header storage only if initial_header was provided
-    if let Some(initial_header) = get_btc_initial_header() {
-        let initial_header_info = initial_header.to_btc_header_info().unwrap();
+    // Test header storage only if base header was provided
+    if let Some(base_header) = get_btc_base_header() {
+        let base_header_info = base_header.to_btc_header_info().unwrap();
         let base_header_height = BTC_HEIGHTS
-            .load(&deps.storage, initial_header_info.hash.as_ref())
+            .load(&deps.storage, base_header_info.hash.as_ref())
             .unwrap();
         assert_eq!(base_header_height, 854784);
 
         let base_header_in_storage = BTC_HEADERS.load(&deps.storage, base_header_height).unwrap();
-        assert_eq!(base_header_in_storage, initial_header_info.encode_to_vec());
+        assert_eq!(base_header_in_storage, base_header_info.encode_to_vec());
     }
 
     // Submit new headers should work only if we have an initial header
-    if get_btc_initial_header().is_some() {
+    if get_btc_base_header().is_some() {
         let new_header: BlockHeader = deserialize(&headers[1].header).unwrap();
         let msg = ExecuteMsg::BtcHeaders {
             headers: vec![new_header.into()],
@@ -112,7 +112,7 @@ fn instantiate_without_initial_header_should_work() {
         network: BitcoinNetwork::Mainnet,
         btc_confirmation_depth: 6,
         checkpoint_finalization_timeout: 100,
-        initial_header: None,
+        base_header: None,
     };
 
     let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -138,7 +138,7 @@ fn instantiate_without_initial_header_should_fail_in_full_validation_mode() {
         network: BitcoinNetwork::Mainnet,
         btc_confirmation_depth: 6,
         checkpoint_finalization_timeout: 100,
-        initial_header: None,
+        base_header: None,
     };
 
     let res = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -168,7 +168,7 @@ fn auto_init_on_first_header_works() {
         network: crate::state::BitcoinNetwork::Regtest,
         btc_confirmation_depth: 6,
         checkpoint_finalization_timeout: 99,
-        initial_header: None,
+        base_header: None,
     };
     let info = message_info(&Addr::unchecked("creator"), &[]);
     instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();

--- a/contracts/btc-light-client/tests/integration.rs
+++ b/contracts/btc-light-client/tests/integration.rs
@@ -32,7 +32,7 @@ fn instantiate_works() {
         network: btc_light_client::BitcoinNetwork::Regtest,
         btc_confirmation_depth: 10,
         checkpoint_finalization_timeout: 100,
-        initial_header: babylon_test_utils::get_btc_initial_header(),
+        base_header: babylon_test_utils::get_btc_base_header(),
     };
     let info = message_info(&Addr::unchecked(CREATOR), &[]);
     let res: ContractResult<Response> = instantiate(&mut deps, mock_env(), info, msg);

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -39,7 +39,7 @@ func NewBTCLightClientInitMsg(network string, k int, w int, initialHeader *btclc
 		"network":                         network,
 		"btc_confirmation_depth":          k,
 		"checkpoint_finalization_timeout": w,
-		"initial_header": map[string]interface{}{
+		"base_header": map[string]interface{}{
 			"header": map[string]interface{}{
 				"version":        btcHeader.Version,
 				"prev_blockhash": btcHeader.PrevBlock.String(),

--- a/packages/proto/Cargo.toml
+++ b/packages/proto/Cargo.toml
@@ -14,6 +14,7 @@ exclude = [ "babylon" ]
 doctest = false
 
 [dependencies]
+bitcoin           = { workspace = true }
 bitvec            = { workspace = true }
 cosmos-sdk-proto  = { workspace = true }
 pbjson-types      = { workspace = true }

--- a/packages/proto/src/impl/babylon.btclightclient.v1.impl.rs
+++ b/packages/proto/src/impl/babylon.btclightclient.v1.impl.rs
@@ -1,0 +1,7 @@
+use bitcoin::block::Header as BlockHeader;
+
+impl BtcHeaderInfo {
+    pub fn block_header(&self) -> Result<BlockHeader, bitcoin::consensus::encode::Error> {
+        bitcoin::consensus::deserialize(self.header.as_ref())
+    }
+}

--- a/packages/proto/src/impls.rs
+++ b/packages/proto/src/impls.rs
@@ -1,0 +1,2 @@
+pub mod babylon_btclightclient_v1;
+pub mod babylon_checkpointing_v1;

--- a/packages/proto/src/impls/babylon_btclightclient_v1.rs
+++ b/packages/proto/src/impls/babylon_btclightclient_v1.rs
@@ -1,3 +1,4 @@
+use crate::babylon::btclightclient::v1::BtcHeaderInfo;
 use bitcoin::block::Header as BlockHeader;
 
 impl BtcHeaderInfo {

--- a/packages/proto/src/impls/babylon_checkpointing_v1.rs
+++ b/packages/proto/src/impls/babylon_checkpointing_v1.rs
@@ -103,13 +103,13 @@ impl RawCheckpoint {
             .map_err(|_| "wrong epoch number bytes length")?;
         let epoch_num = u64::from_be_bytes(epoch_num_bytes);
         idx += EPOCH_LEN;
-        let block_hash: Vec<u8> = raw_ckpt_bytes[idx..idx + BLOCK_HASH_LEN].to_vec().clone();
+        let block_hash: Vec<u8> = raw_ckpt_bytes[idx..idx + BLOCK_HASH_LEN].to_vec();
         idx += BLOCK_HASH_LEN;
-        let bitmap: Vec<u8> = raw_ckpt_bytes[idx..idx + BITMAP_LEN].to_vec().clone();
+        let bitmap: Vec<u8> = raw_ckpt_bytes[idx..idx + BITMAP_LEN].to_vec();
         idx += BITMAP_LEN;
-        let _: Vec<u8> = raw_ckpt_bytes[idx..idx + ADDRESS_LEN].to_vec().clone();
+        let _: Vec<u8> = raw_ckpt_bytes[idx..idx + ADDRESS_LEN].to_vec();
         idx += ADDRESS_LEN;
-        let bls_multi_sig: Vec<u8> = raw_ckpt_bytes[idx..idx + BLS_SIG_LEN].to_vec().clone();
+        let bls_multi_sig: Vec<u8> = raw_ckpt_bytes[idx..idx + BLS_SIG_LEN].to_vec();
 
         let raw_ckpt = RawCheckpoint {
             epoch_num,

--- a/packages/proto/src/impls/babylon_checkpointing_v1.rs
+++ b/packages/proto/src/impls/babylon_checkpointing_v1.rs
@@ -1,3 +1,6 @@
+use crate::babylon::checkpointing::v1::{
+    RawCheckpoint, ValidatorWithBlsKey, ValidatorWithBlsKeySet,
+};
 use bitvec::prelude::*;
 use sha2::{Digest, Sha256};
 
@@ -44,9 +47,14 @@ impl ValidatorWithBlsKeySet {
         }
 
         for i in 0..self.val_set.len() {
-            let bit = *bitmap.get(i).ok_or(format!("bitmap does not contain bit at index {}", i))?;
+            let bit = *bitmap
+                .get(i)
+                .ok_or(format!("bitmap does not contain bit at index {}", i))?;
             if bit {
-                let voted_val = self.val_set.get(i).ok_or(format!("validator set does not contain validator at index {}", i))?;
+                let voted_val = self.val_set.get(i).ok_or(format!(
+                    "validator set does not contain validator at index {}",
+                    i
+                ))?;
                 val_subset.push(voted_val.clone());
                 sum += voted_val.voting_power;
             }
@@ -91,13 +99,11 @@ impl RawCheckpoint {
         // start decoding
         let mut idx: usize = 0;
         let epoch_num_bytes: [u8; 8] = raw_ckpt_bytes[idx..idx + EPOCH_LEN]
-                                            .try_into()
-                                            .map_err(|_| "wrong epoch number bytes length")?;
+            .try_into()
+            .map_err(|_| "wrong epoch number bytes length")?;
         let epoch_num = u64::from_be_bytes(epoch_num_bytes);
         idx += EPOCH_LEN;
-        let block_hash: Vec<u8> = raw_ckpt_bytes[idx..idx + BLOCK_HASH_LEN]
-            .to_vec()
-            .clone();
+        let block_hash: Vec<u8> = raw_ckpt_bytes[idx..idx + BLOCK_HASH_LEN].to_vec().clone();
         idx += BLOCK_HASH_LEN;
         let bitmap: Vec<u8> = raw_ckpt_bytes[idx..idx + BITMAP_LEN].to_vec().clone();
         idx += BITMAP_LEN;

--- a/packages/proto/src/lib.rs
+++ b/packages/proto/src/lib.rs
@@ -1,3 +1,5 @@
+mod impls;
+
 pub mod babylon {
     // Skip for the auto-generated code.
     #![allow(clippy::doc_lazy_continuation)]
@@ -18,7 +20,6 @@ pub mod babylon {
             #![allow(clippy::large_enum_variant)]
             include!("gen/babylon.btclightclient.v1.rs");
             // @@protoc_insertion_point(babylon.btclightclient.v1)
-            include!("impl/babylon.btclightclient.v1.impl.rs");
         }
     }
     pub mod checkpointing {
@@ -28,7 +29,7 @@ pub mod babylon {
             #![allow(clippy::large_enum_variant)]
             include!("gen/babylon.checkpointing.v1.rs");
             // @@protoc_insertion_point(babylon.checkpointing.v1)
-            include!("impl/babylon.checkpointing.v1.impl.rs");
+            pub use crate::impls::babylon_checkpointing_v1::*;
         }
     }
     pub mod epoching {

--- a/packages/proto/src/lib.rs
+++ b/packages/proto/src/lib.rs
@@ -18,6 +18,7 @@ pub mod babylon {
             #![allow(clippy::large_enum_variant)]
             include!("gen/babylon.btclightclient.v1.rs");
             // @@protoc_insertion_point(babylon.btclightclient.v1)
+            include!("impl/babylon.btclightclient.v1.impl.rs");
         }
     }
     pub mod checkpointing {

--- a/packages/test-utils/src/lib.rs
+++ b/packages/test-utils/src/lib.rs
@@ -351,9 +351,9 @@ pub fn get_public_randomness_commitment() -> (String, PubRandCommit, Vec<u8>) {
 }
 
 /// Returns the initial BTC header for the babylon contract instantiation.
-pub fn btc_initial_header() -> btc_light_client::msg::contract::InitialHeader {
+pub fn btc_base_header() -> btc_light_client::msg::contract::BaseHeader {
     // Initial base header on Babylon Genesis mainnet, https://www.blockchain.com/explorer/blocks/btc/854784.
-    // TODO: This hardcodes a mainnet header in `btc_initial_header`, which may be incorrect in a
+    // TODO: This hardcodes a mainnet header in `btc_base_header`, which may be incorrect in a
     // different network context, and we do often use different networks (e.g., testnet or regtest) in the test environment.
     // It's fine for now, but we should make this function network-aware to avoid subtle bugs down the line.
     let header = "0000c020f382af1f6d228721b49f3da2f5b831587803b16597b301000000000000000000e4f76aae64d8316d195a92424871b74168b58d1c3c6988548e0e9890b15fc2fc3c00aa66be1a0317082e4bc7";
@@ -372,12 +372,12 @@ pub fn btc_initial_header() -> btc_light_client::msg::contract::InitialHeader {
 
 /// Helper function to get the appropriate initial header value based on the full-validation feature
 ///
-/// When the full-validation feature is enabled, returns Some(btc_initial_header).
+/// When the full-validation feature is enabled, returns Some(btc_base_header).
 /// When the full-validation feature is disabled, returns None.
-pub fn get_btc_initial_header() -> Option<btc_light_client::msg::contract::InitialHeader> {
+pub fn get_btc_base_header() -> Option<btc_light_client::msg::contract::BaseHeader> {
     #[cfg(feature = "full-validation")]
     {
-        Some(btc_initial_header())
+        Some(btc_base_header())
     }
     #[cfg(not(feature = "full-validation"))]
     {


### PR DESCRIPTION
This PR includes a series of refactorings and improvements to the btc-light-client contract, focusing on code clarity, error handling, and adherence to Rust best practices.  Reviewing commit by commit and looking at the commit message should make the most sense.

Key Changes:

   * **Naming and API Consistency:**
       * Renamed `initial_header` to `base_header` for consistency. This is a breaking change :( @gitferry 
       * Introduced a `block_header()` method for `BtcHeaderInfo`.
   * **Simplified Header Processing:**
       * The logic for processing BTC headers has been made more concise by extracting a `convert_to_btc_header_info` function and using `split_first` to handle the base header.
       * The `init_btc_headers` function now accepts `first_work` by value since it's `Copy`, simplifying its signature.
   * **Improved Error Handling:**
       * The `InsufficientHeaders` error now provides more context by including both the required and actual number of headers, which will aid in debugging.
   * **Code Organization and Readability:**
       * The `migrate` function has been moved to a more logical location.
       * The visibility of the internal function `handle_btc_headers_from_babylon` has been correctly scoped to `pub(crate)`.
       * Variable definitions have been moved closer to their usage.
       
 Initially, I was trying to resolve this comment https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/229#discussion_r2227963292, but it became another series of refactorings. Now I think it's mostly good to start the examination of the misalignment :P
 
 The follow-up is to rename all the initial header items to _base header_ in Go files.
