### PR TITLE
fix(btc-light-client): rename `is_difficulty_boundary()` to `is_retarget_block()` and fix the misalignment

### DIFF
--- a/contracts/btc-light-client/src/msg/contract.rs
+++ b/contracts/btc-light-client/src/msg/contract.rs
@@ -70,10 +70,8 @@ impl InstantiateMsg {
         }
 
         if let Some(ref base_header) = self.base_header {
-            if !crate::bitcoin::is_retarget_block(
-                base_header.height,
-                &self.network.chain_params(),
-            ) {
+            if !crate::bitcoin::is_retarget_block(base_header.height, &self.network.chain_params())
+            {
                 return Err(ContractError::NotOnDifficultyBoundary(base_header.height));
             }
         }

--- a/contracts/btc-light-client/src/msg/contract.rs
+++ b/contracts/btc-light-client/src/msg/contract.rs
@@ -70,7 +70,7 @@ impl InstantiateMsg {
         }
 
         if let Some(ref base_header) = self.base_header {
-            if !crate::bitcoin::is_difficulty_change_boundary(
+            if !crate::bitcoin::is_retarget_block(
                 base_header.height,
                 &self.network.chain_params(),
             ) {


### PR DESCRIPTION
This fixes the misalignment in the difficulty block adjustment check. Can't recall why `height >= difficulty_adjustment_interval` was added previously, anyway, now it aligns with the Go implementation, with the reference attached in the comment. Not 100% if it's conceptually right that the block 0 is also a retarget block, but it's aligned at least :(