### PR TITLE
fix: fix Babylon SDK e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#270](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/270) fix: fix Babylon SDK e2e
 - [#265](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/265) finality: handle public randomness misalignment
 - [#260](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/260) chore: manual changelog setup
 

--- a/contracts/babylon/src/contract.rs
+++ b/contracts/babylon/src/contract.rs
@@ -165,16 +165,8 @@ fn reply_init_callback_light_client(
     // Try to get contract address from events in reply
     let addr = reply_init_get_contract_address(&reply)?;
 
-    // Fetch the first msg_response as the base header data of BTC light client.
-    let base_header_bytes = reply
-        .msg_responses
-        .into_iter()
-        .next()
-        .ok_or(ContractError::MissingBaseHeaderInBtcLightClientResponse)?
-        .value;
-
     CONFIG.update(deps.storage, |mut cfg| {
-        cfg.btc_light_client = Some((addr, base_header_bytes));
+        cfg.btc_light_client = Some(addr);
         Ok::<_, ContractError>(cfg)
     })?;
 
@@ -209,7 +201,10 @@ fn reply_init_callback_finality(
     // Set the BTC finality contract address to the BTC staking contract
     let cfg = CONFIG.load(deps.storage)?;
     let msg = btc_staking_api::ExecuteMsg::UpdateContractAddresses {
-        btc_light_client: cfg.btc_light_client_addr()?,
+        btc_light_client: cfg
+            .btc_light_client
+            .ok_or(ContractError::BtcLightClientNotSet {})?
+            .to_string(),
         finality: cfg
             .btc_finality
             .ok_or(ContractError::BtcFinalityNotSet {})?

--- a/contracts/babylon/src/ibc.rs
+++ b/contracts/babylon/src/ibc.rs
@@ -276,10 +276,7 @@ pub(crate) mod ibc_packet {
                     fork_app_hash: evidence.fork_app_hash.to_vec().into(),
                     canonical_finality_sig: evidence.canonical_finality_sig.to_vec().into(),
                     fork_finality_sig: evidence.fork_finality_sig.to_vec().into(),
-                    signing_context: babylon_apis::signing_context::fp_fin_vote_context_v0(
-                        &env.block.chain_id,
-                        env.contract.address.as_str(),
-                    ),
+                    signing_context: evidence.signing_context.clone(),
                 }),
             })),
         };

--- a/contracts/babylon/src/multitest.rs
+++ b/contracts/babylon/src/multitest.rs
@@ -21,7 +21,7 @@ fn initialization() {
     assert_eq!(config.checkpoint_finalization_timeout, 1);
     assert!(!config.notify_cosmos_zone);
     assert_eq!(
-        config.btc_light_client_addr().unwrap().as_str(),
+        config.btc_light_client.unwrap().as_str(),
         BTC_LIGHT_CLIENT_CONTRACT_ADDR
     );
     assert_eq!(
@@ -57,7 +57,7 @@ mod instantiation {
     fn contract_should_be_instantiated(config: Config) {
         // Confirm the btc-light-client contract has been instantiated and set
         assert_eq!(
-            config.btc_light_client_addr().unwrap().as_str(),
+            config.btc_light_client.unwrap().as_str(),
             BTC_LIGHT_CLIENT_CONTRACT_ADDR
         );
         // Confirm the btc-staking contract has been instantiated and set

--- a/contracts/babylon/src/state/config.rs
+++ b/contracts/babylon/src/state/config.rs
@@ -1,6 +1,5 @@
-use crate::error::ContractError;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Binary};
+use cosmwasm_std::Addr;
 use cw_storage_plus::Item;
 
 pub(crate) const CONFIG: Item<Config> = Item::new("config");
@@ -15,13 +14,8 @@ pub struct Config {
     /// NOTE: if set to true, then the Cosmos zone needs to integrate the corresponding message
     /// handler as well
     pub notify_cosmos_zone: bool,
-    /// If set, this stores the config for BTC light client contract on the Consumer.
-    ///
-    /// This consists of a tuple: `(btc_light_client_address, encoded_btc_base_header)`,
-    /// where:
-    /// - `btc_light_client_address` is the address of the BTC light client contract.
-    /// - `encoded_btc_base_header` is the encoded base Bitcoin header to initialize the light client.
-    pub btc_light_client: Option<(Addr, Binary)>,
+    /// If set, this stores the address of the BTC light client contract on the Consumer.
+    pub btc_light_client: Option<Addr>,
     /// If set, this stores a BTC staking contract used for BTC re-staking
     pub btc_staking: Option<Addr>,
     /// If set, this stores a BTC finality contract used for BTC finality on the Consumer
@@ -31,14 +25,4 @@ pub struct Config {
     /// Consumer description
     pub consumer_description: Option<String>,
     pub denom: String,
-}
-
-impl Config {
-    /// Returns the address of BTC light client contract, return an error if not found.
-    pub fn btc_light_client_addr(&self) -> Result<String, ContractError> {
-        self.btc_light_client
-            .as_ref()
-            .map(|(addr, _)| addr.to_string())
-            .ok_or(ContractError::BtcLightClientNotSet {})
-    }
 }

--- a/contracts/babylon/src/state/consumer_header_chain.rs
+++ b/contracts/babylon/src/state/consumer_header_chain.rs
@@ -58,6 +58,7 @@ pub fn get_consumer_header(
     Ok(indexed_header)
 }
 
+#[allow(dead_code)]
 fn verify_consumer_header(
     _deps: Deps,
     _consumer_header: &IndexedHeader,
@@ -82,16 +83,7 @@ fn insert_consumer_header(deps: &mut DepsMut, consumer_header: &IndexedHeader) -
 pub fn handle_consumer_header(
     deps: &mut DepsMut,
     consumer_header: &IndexedHeader,
-    epoch: &Epoch,
-    proof_consumer_header_in_epoch: &ProofOps,
 ) -> Result<(), error::ConsumerHeaderChainError> {
-    verify_consumer_header(
-        deps.as_ref(),
-        consumer_header,
-        epoch,
-        proof_consumer_header_in_epoch,
-    )?;
-
     insert_consumer_header(deps, consumer_header)?;
 
     Ok(())

--- a/contracts/babylon/src/state/mod.rs
+++ b/contracts/babylon/src/state/mod.rs
@@ -91,26 +91,7 @@ pub fn handle_btc_timestamp(
     if let Some(consumer_header) = btc_ts.header.as_ref() {
         deps.api
             .debug("handle_btc_timestamp: found consumer header, processing");
-        let proof = btc_ts.proof.as_ref().ok_or_else(|| {
-            let err_msg = "empty proof in BTC timestamp";
-            deps.api.debug(&format!("handle_btc_timestamp: {err_msg}"));
-            StdError::generic_err(err_msg)
-        })?;
-        let proof_consumer_header_in_epoch = proof
-            .proof_consumer_header_in_epoch
-            .as_ref()
-            .ok_or_else(|| {
-                let err_msg = "empty proof_consumer_header_in_epoch in proof";
-                deps.api.debug(&format!("handle_btc_timestamp: {err_msg}"));
-                StdError::generic_err(err_msg)
-            })?;
-        consumer_header_chain::handle_consumer_header(
-            deps,
-            consumer_header,
-            epoch,
-            proof_consumer_header_in_epoch,
-        )
-        .map_err(|e| {
+        consumer_header_chain::handle_consumer_header(deps, consumer_header).map_err(|e| {
             let err_msg = format!("failed to handle Consumer header from Babylon: {e}");
             deps.api.debug(&format!("handle_btc_timestamp: {err_msg}"));
             StdError::generic_err(err_msg)

--- a/contracts/babylon/src/utils/btc_light_client_executor.rs
+++ b/contracts/babylon/src/utils/btc_light_client_executor.rs
@@ -10,7 +10,9 @@ pub fn new_btc_headers_msg(
     headers: &[BtcHeaderInfo],
 ) -> Result<WasmMsg, ContractError> {
     let cfg = CONFIG.load(deps.storage)?;
-    let contract_addr = cfg.btc_light_client_addr()?;
+    let contract_addr = cfg
+        .btc_light_client
+        .ok_or(ContractError::BtcLightClientNotSet {})?;
 
     let btc_headers = btc_headers_from_info(headers)?;
 
@@ -24,7 +26,7 @@ pub fn new_btc_headers_msg(
         first_height: Some(first_height),
     };
     let wasm_msg = WasmMsg::Execute {
-        contract_addr,
+        contract_addr: contract_addr.to_string(),
         msg: to_json_binary(&msg)?,
         funds: vec![],
     };

--- a/contracts/babylon/src/utils/btc_light_client_querier.rs
+++ b/contracts/babylon/src/utils/btc_light_client_querier.rs
@@ -7,7 +7,10 @@ use cosmwasm_std::Deps;
 #[allow(dead_code)]
 fn get_contract_addr(deps: Deps) -> Result<String, ContractError> {
     let cfg = CONFIG.load(deps.storage)?;
-    cfg.btc_light_client_addr()
+    let contract_addr = cfg
+        .btc_light_client
+        .ok_or(ContractError::BtcLightClientNotSet {})?;
+    Ok(contract_addr.to_string())
 }
 
 /// Query the tip header from the BTC light client

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -17,7 +17,7 @@ mod instantiation {
         // Confirm the btc-light-client contract has been instantiated and set
         let config = suite.get_babylon_config();
         assert_eq!(
-            config.btc_light_client_addr().unwrap().as_str(),
+            config.btc_light_client.unwrap().as_str(),
             BTC_LIGHT_CLIENT_CONTRACT_ADDR
         );
         // Confirm the btc-staking contract has been instantiated and set

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -262,7 +262,7 @@ pub(crate) fn handle_btc_headers_from_babylon(
         let new_tip_work = total_work(new_tip.work.as_ref())?;
         let cur_tip_work = total_work(cur_tip.work.as_ref())?;
 
-        if new_tip_work < cur_tip_work {
+        if new_tip_work <= cur_tip_work {
             return Err(ContractError::InsufficientWork(new_tip_work, cur_tip_work));
         }
 
@@ -479,10 +479,10 @@ pub(crate) mod tests {
         // get fork headers
         let test_fork_headers = get_btc_lc_fork_headers();
 
-        // handling fork headers minus the two last
+        // handling fork headers minus the last
         let res = handle_btc_headers_from_babylon(
             &mut storage,
-            &test_fork_headers[..test_fork_headers.len() - 2],
+            &test_fork_headers[..test_fork_headers.len() - 1],
         );
         assert!(matches!(
             res.unwrap_err(),

--- a/contracts/btc-light-client/src/contract.rs
+++ b/contracts/btc-light-client/src/contract.rs
@@ -242,7 +242,6 @@ pub(crate) fn handle_btc_headers_from_babylon(
 
     // decode the first header in these new headers
     let first_new_header = new_headers.first().ok_or(ContractError::EmptyHeaders {})?;
-
     let first_new_btc_header = first_new_header.block_header()?;
 
     let new_tip = if first_new_btc_header.prev_blockhash.as_ref() == cur_tip_hash.to_vec() {
@@ -263,7 +262,7 @@ pub(crate) fn handle_btc_headers_from_babylon(
         let new_tip_work = total_work(new_tip.work.as_ref())?;
         let cur_tip_work = total_work(cur_tip.work.as_ref())?;
 
-        if new_tip_work <= cur_tip_work {
+        if new_tip_work < cur_tip_work {
             return Err(ContractError::InsufficientWork(new_tip_work, cur_tip_work));
         }
 
@@ -480,10 +479,10 @@ pub(crate) mod tests {
         // get fork headers
         let test_fork_headers = get_btc_lc_fork_headers();
 
-        // handling fork headers minus the last
+        // handling fork headers minus the two last
         let res = handle_btc_headers_from_babylon(
             &mut storage,
-            &test_fork_headers[..test_fork_headers.len() - 1],
+            &test_fork_headers[..test_fork_headers.len() - 2],
         );
         assert!(matches!(
             res.unwrap_err(),

--- a/e2e/types/test_client.go
+++ b/e2e/types/test_client.go
@@ -269,9 +269,9 @@ func (p *TestConsumerClient) deployContracts() (*ConsumerContract, error) {
 	}
 
 	var config struct {
-		BTCLightClient []string `json:"btc_light_client"`
-		BTCStaking     string   `json:"btc_staking"`
-		BTCFinality    string   `json:"btc_finality"`
+		BTCLightClient string `json:"btc_light_client"`
+		BTCStaking     string `json:"btc_staking"`
+		BTCFinality    string `json:"btc_finality"`
 	}
 	err = json.Unmarshal(configRes, &config)
 	if err != nil {
@@ -281,7 +281,7 @@ func (p *TestConsumerClient) deployContracts() (*ConsumerContract, error) {
 	// Set BSN contracts in the Babylon module
 	contracts := &babylontypes.BSNContracts{
 		BabylonContract:        babylonAddr,
-		BtcLightClientContract: config.BTCLightClient[0], // First element is the contract address
+		BtcLightClientContract: config.BTCLightClient, // First element is the contract address
 		BtcStakingContract:     config.BTCStaking,
 		BtcFinalityContract:    config.BTCFinality,
 	}
@@ -292,7 +292,7 @@ func (p *TestConsumerClient) deployContracts() (*ConsumerContract, error) {
 	}
 
 	// Verify that the contracts exist in the wasm keeper
-	btcLightClientAccAddr, err := sdk.AccAddressFromBech32(config.BTCLightClient[0])
+	btcLightClientAccAddr, err := sdk.AccAddressFromBech32(config.BTCLightClient)
 	if err != nil {
 		return nil, fmt.Errorf("invalid btc light client address: %w", err)
 	}

--- a/e2e/types/test_client.go
+++ b/e2e/types/test_client.go
@@ -281,7 +281,7 @@ func (p *TestConsumerClient) deployContracts() (*ConsumerContract, error) {
 	// Set BSN contracts in the Babylon module
 	contracts := &babylontypes.BSNContracts{
 		BabylonContract:        babylonAddr,
-		BtcLightClientContract: config.BTCLightClient, // First element is the contract address
+		BtcLightClientContract: config.BTCLightClient,
 		BtcStakingContract:     config.BTCStaking,
 		BtcFinalityContract:    config.BTCFinality,
 	}


### PR DESCRIPTION
This PR fixes various issues uncovered during debugging Babylon SDK e2e. These include

- Removing the concept of base BTC header completely in all contracts, not just BTC light client contract
- Using correct signing context for BSN FP slashing IBC packet
- Omitting unpacking certain fields in BTC timestamps

Prerequisite of https://github.com/babylonlabs-io/babylon-sdk/pull/182
