### PR TITLE
finality: refactor voting power table in BTC finality contract, and fix finality signature handling/tallying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### State breaking
 
+- [#276](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/276) finality: fix finality voting issue
 - [#272](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/272) ibc: set proper timeout for IBC packets
 
 ### Improvements

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -136,6 +136,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
         QueryMsg::ActiveFinalityProviders { height } => Ok(to_json_binary(
             &queries::active_finality_providers(deps, height)?,
         )?),
+        QueryMsg::FinalityProviderPower { btc_pk_hex, height } => Ok(to_json_binary(
+            &queries::finality_provider_power(deps, btc_pk_hex, height)?,
+        )?),
     }
 }
 

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -252,7 +252,7 @@ pub fn handle_finality_signature(
     //     this means Babylon will lose safety under an adaptive adversary corrupting even 1
     //     finality provider. It can simply corrupt a new finality provider and equivocate a
     //     historical block over and over again, making a previous block not finalisable forever
-    if fp.slashed_height > 0 && fp.slashed_height < height {
+    if fp.slashed_height > 0 {
         return Err(ContractError::FinalityProviderAlreadySlashed(
             fp_btc_pk_hex.to_string(),
         ));

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -749,11 +749,9 @@ pub fn compute_active_finality_providers(
 
     // Online FPs verification
     // Store starting heights of fps entering the active set
-    let old_fps = get_power_table_at_height(deps.storage, env.block.height - 1)?
-        .keys()
-        .cloned()
-        .collect();
-    let cur_fps: HashSet<String> = fp_power_table.keys().cloned().collect();
+    let old_power_table = get_power_table_at_height(deps.storage, env.block.height - 1)?;
+    let old_fps = old_power_table.keys().collect();
+    let cur_fps: HashSet<_> = fp_power_table.keys().collect();
     let new_fps = cur_fps.difference(&old_fps);
     for fp in new_fps {
         // Active since the next block. Only save if not already set
@@ -798,9 +796,7 @@ pub fn compute_active_finality_providers(
     Ok(())
 }
 
-/// Query BTC staking contract for finality providers by total active sats.
-///
-/// This is used to get the finality providers with the highest total active sats.
+/// Queries the BTC staking contract for finality providers ordered by total active sats.
 pub fn query_fps_by_total_active_sats(
     staking_addr: &Addr,
     querier: &QuerierWrapper,

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -2,7 +2,8 @@ use crate::contract::encode_smart_query;
 use crate::error::ContractError;
 use crate::state::config::{ADMIN, CONFIG, PARAMS};
 use crate::state::finality::{
-    BLOCKS, EVIDENCES, FP_BLOCK_SIGNER, FP_SET, FP_START_HEIGHT, JAIL, NEXT_HEIGHT, SIGNATURES,
+    get_power_table_at_height, BLOCKS, EVIDENCES, FP_BLOCK_SIGNER, FP_POWER_TABLE, FP_START_HEIGHT,
+    JAIL, NEXT_HEIGHT, SIGNATURES,
 };
 use crate::state::public_randomness::{
     get_last_finalized_height, get_last_pub_rand_commit,
@@ -13,7 +14,7 @@ use babylon_apis::btc_staking_api::FinalityProvider;
 use babylon_apis::finality_api::{Evidence, IndexedBlock, PubRandCommit};
 use babylon_apis::to_canonical_addr;
 use babylon_merkle::Proof;
-use btc_staking::msg::{FinalityProviderInfo, FinalityProvidersByPowerResponse};
+use btc_staking::msg::{FinalityProviderInfo, FinalityProvidersByTotalActiveSatsResponse};
 use cosmwasm_std::Order::Ascending;
 use cosmwasm_std::{
     to_json_binary, Addr, DepsMut, Env, Event, MessageInfo, QuerierWrapper, Response, StdResult,
@@ -22,7 +23,7 @@ use cosmwasm_std::{
 use k256::schnorr::{signature::Verifier, Signature, VerifyingKey};
 use k256::sha2::{Digest, Sha256};
 use std::cmp::max;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 // The maximum number of blocks into the future
 // that a public randomness commitment start height can target. This limit prevents abuse by capping
@@ -258,17 +259,8 @@ pub fn handle_finality_signature(
     }
 
     // Ensure the finality provider has voting power at this height
-    let fp: FinalityProviderInfo = deps
-        .querier
-        .query_wasm_smart(
-            staking_addr.clone(),
-            &btc_staking::msg::QueryMsg::FinalityProviderInfo {
-                btc_pk_hex: fp_btc_pk_hex.to_string(),
-                height: Some(height),
-            },
-        )
-        .map_err(|_| ContractError::NoVotingPower(fp_btc_pk_hex.to_string(), height))?;
-    if fp.power == 0 {
+    let fp_power = FP_POWER_TABLE.load(deps.storage, (height, fp_btc_pk_hex))?;
+    if fp_power == 0 {
         return Err(ContractError::NoVotingPower(
             fp_btc_pk_hex.to_string(),
             height,
@@ -614,16 +606,17 @@ pub fn tally_blocks(
     for h in start_height..=env.block.height {
         let mut indexed_block = BLOCKS.load(deps.storage, h)?;
         // Get the finality provider set of this block
-        let fp_set = FP_SET.may_load(deps.storage, h)?;
+        let fp_power_table = get_power_table_at_height(deps.storage, h)?;
+        let has_fp = !fp_power_table.is_empty();
 
-        match (fp_set, indexed_block.finalized) {
-            (Some(fp_set), false) => {
+        match (has_fp, indexed_block.finalized) {
+            (true, false) => {
                 // Has finality providers, non-finalised: tally and try to finalise the block
                 let voter_btc_pks = SIGNATURES
                     .prefix(indexed_block.height)
                     .keys(deps.storage, None, None, Ascending)
                     .collect::<StdResult<Vec<_>>>()?;
-                if tally(&fp_set, &voter_btc_pks) {
+                if tally(&fp_power_table, &voter_btc_pks) {
                     // If this block gets >2/3 votes, finalise it
                     let ev = finalize_block(deps.storage, &mut indexed_block, &voter_btc_pks)?;
                     events.push(ev);
@@ -633,20 +626,20 @@ pub fn tally_blocks(
                     break;
                 }
             }
-            (None, false) => {
+            (false, false) => {
                 // Does not have finality providers, non-finalised: not finalisable,
                 // Increment the next height to finalise and continue
                 NEXT_HEIGHT.save(deps.storage, &(indexed_block.height + 1))?;
                 continue;
             }
-            (Some(_), true) => {
+            (true, true) => {
                 // Has finality providers and the block is finalised.
                 // This can only be a programming error
                 return Err(ContractError::FinalisedBlockWithFinalityProviderSet(
                     indexed_block.height,
                 ));
             }
-            (None, true) => {
+            (false, true) => {
                 // Does not have finality providers, finalised: impossible to happen
                 return Err(ContractError::FinalisedBlockWithoutFinalityProviderSet(
                     indexed_block.height,
@@ -659,14 +652,14 @@ pub fn tally_blocks(
 }
 
 /// Checks whether a block with the given finality provider set and votes reaches a quorum or not.
-fn tally(fp_set: &[FinalityProviderInfo], voters: &[String]) -> bool {
+fn tally(fp_power_table: &HashMap<String, u64>, voters: &[String]) -> bool {
     let voters: HashSet<String> = voters.iter().cloned().collect();
     let mut total_power = 0;
     let mut voted_power = 0;
-    for fp_info in fp_set {
-        total_power += fp_info.power;
-        if voters.contains(&fp_info.btc_pk_hex) {
-            voted_power += fp_info.power;
+    for (fp_btc_pk_hex, power) in fp_power_table {
+        total_power += power;
+        if voters.contains(fp_btc_pk_hex) {
+            voted_power += power;
         }
     }
     voted_power * 3 > total_power * 2
@@ -706,53 +699,65 @@ pub fn compute_active_finality_providers(
     let last_finalized_height = get_last_finalized_height(&deps.as_ref())?;
 
     // Get all finality providers from the staking contract, filtered
-    let mut batch = list_fps_by_power(&cfg.staking, &deps.querier, None, QUERY_LIMIT)?;
+    let mut batch = query_fps_by_total_active_sats(&cfg.staking, &deps.querier, None, QUERY_LIMIT)?;
 
-    let mut finality_providers = vec![];
+    let mut fp_power_table = HashMap::new();
     let mut total_power: u64 = 0;
-    while !batch.is_empty() && finality_providers.len() < max_active_fps {
+    while !batch.is_empty() && fp_power_table.len() < max_active_fps {
         let last = batch.last().cloned();
 
         let (filtered, running_total): (Vec<_>, Vec<_>) = batch
             .into_iter()
             .filter(|fp| {
-                // Filter out FPs with no voting power
-                if fp.power == 0 {
+                // Filter out FPs with no active sats (also includes slashed FPs)
+                if fp.total_active_sats == 0 {
                     return false;
                 }
                 // Filter out FPs that are jailed.
                 // Error (shouldn't happen) is being mapped to "jailed forever"
-                JAIL.may_load(deps.storage, &fp.btc_pk_hex)
+                if JAIL
+                    .may_load(deps.storage, &fp.btc_pk_hex)
                     .unwrap_or(Some(JAIL_FOREVER))
-                    .is_none()
+                    .is_some()
+                {
+                    return false;
+                }
                 // Filter out FPs that don't have timestamped public randomness
-                && has_timestamped_pub_rand_commit_for_height(&deps.as_ref(), &fp.btc_pk_hex, env.block.height, Some(last_finalized_height))
+                if !has_timestamped_pub_rand_commit_for_height(
+                    &deps.as_ref(),
+                    &fp.btc_pk_hex,
+                    env.block.height,
+                    Some(last_finalized_height),
+                ) {
+                    return false;
+                }
+
+                true
             })
             .scan(total_power, |acc, fp| {
-                *acc += fp.power;
+                *acc += fp.total_active_sats;
                 Some((fp, *acc))
             })
             .unzip();
 
-        finality_providers.extend_from_slice(&filtered);
+        // Add the filtered finality providers to the power table
+        for fp in filtered {
+            fp_power_table.insert(fp.btc_pk_hex, fp.total_active_sats);
+        }
+        // Update the total power
         total_power = running_total.last().copied().unwrap_or_default();
 
         // and get the next page
-        batch = list_fps_by_power(&cfg.staking, &deps.querier, last, QUERY_LIMIT)?;
+        batch = query_fps_by_total_active_sats(&cfg.staking, &deps.querier, last, QUERY_LIMIT)?;
     }
 
     // Online FPs verification
     // Store starting heights of fps entering the active set
-    let old_fps: HashSet<String> = FP_SET
-        .may_load(deps.storage, env.block.height - 1)?
-        .unwrap_or(vec![])
-        .iter()
-        .map(|fp| fp.btc_pk_hex.clone())
+    let old_fps = get_power_table_at_height(deps.storage, env.block.height - 1)?
+        .keys()
+        .cloned()
         .collect();
-    let cur_fps: HashSet<String> = finality_providers
-        .iter()
-        .map(|fp| fp.btc_pk_hex.clone())
-        .collect();
+    let cur_fps: HashSet<String> = fp_power_table.keys().cloned().collect();
     let new_fps = cur_fps.difference(&old_fps);
     for fp in new_fps {
         // Active since the next block. Only save if not already set
@@ -764,11 +769,11 @@ pub fn compute_active_finality_providers(
 
     // Check for inactive finality providers, and jail them
     let params = PARAMS.load(deps.storage)?;
-    finality_providers.iter().try_for_each(|fp| {
-        let mut last_sign_height = FP_BLOCK_SIGNER.may_load(deps.storage, &fp.btc_pk_hex)?;
+    fp_power_table.iter().try_for_each(|(fp_btc_pk_hex, _)| {
+        let mut last_sign_height = FP_BLOCK_SIGNER.may_load(deps.storage, fp_btc_pk_hex)?;
         if last_sign_height.is_none() {
             // Not a block signer yet, check their start height instead
-            last_sign_height = FP_START_HEIGHT.may_load(deps.storage, &fp.btc_pk_hex)?;
+            last_sign_height = FP_START_HEIGHT.may_load(deps.storage, fp_btc_pk_hex)?;
         }
         match last_sign_height {
             Some(h) if h > env.block.height.saturating_sub(params.missed_blocks_window) => {
@@ -776,7 +781,7 @@ pub fn compute_active_finality_providers(
             }
             _ => {
                 // FP is inactive for at least missed_blocks_window, jail! (if not already jailed)
-                JAIL.update(deps.storage, &fp.btc_pk_hex, |jailed| match jailed {
+                JAIL.update(deps.storage, fp_btc_pk_hex, |jailed| match jailed {
                     Some(jail_time) => Ok::<_, ContractError>(jail_time),
                     None => Ok(env.block.time.seconds() + params.jail_duration),
                 })?;
@@ -786,13 +791,21 @@ pub fn compute_active_finality_providers(
     })?;
 
     // Save the new set of active finality providers
-    // TODO: Purge old (height - finality depth) FP_SET entries to avoid bloating the storage (#124)
-    FP_SET.save(deps.storage, env.block.height, &finality_providers)?;
+    for (fp_btc_pk_hex, power) in fp_power_table {
+        FP_POWER_TABLE.save(
+            deps.storage,
+            (env.block.height, fp_btc_pk_hex.as_str()),
+            &power,
+        )?;
+    }
 
     Ok(())
 }
 
-pub fn list_fps_by_power(
+/// Query BTC staking contract for finality providers by total active sats.
+///
+/// This is used to get the finality providers with the highest total active sats.
+pub fn query_fps_by_total_active_sats(
     staking_addr: &Addr,
     querier: &QuerierWrapper,
     start_after: Option<FinalityProviderInfo>,
@@ -800,8 +813,8 @@ pub fn list_fps_by_power(
 ) -> StdResult<Vec<FinalityProviderInfo>> {
     let query = encode_smart_query(
         staking_addr,
-        &btc_staking::msg::QueryMsg::FinalityProvidersByPower { start_after, limit },
+        &btc_staking::msg::QueryMsg::FinalityProvidersByTotalActiveSats { start_after, limit },
     )?;
-    let res: FinalityProvidersByPowerResponse = querier.query(&query)?;
+    let res: FinalityProvidersByTotalActiveSatsResponse = querier.query(&query)?;
     Ok(res.fps)
 }

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -308,11 +308,9 @@ pub fn handle_finality_signature(
     )?;
 
     // The public randomness value is good, save it.
-    // TODO?: Don't save public randomness values, to save storage space (#124)
     PUB_RAND_VALUES.save(deps.storage, (fp_btc_pk_hex, height), &pub_rand.to_vec())?;
 
     // Verify whether the voted block is a fork or not
-    // TODO?: Do not rely on 'canonical' (i.e. BFT-consensus provided) blocks info
     let indexed_block = BLOCKS
         .load(deps.storage, height)
         .map_err(|err| ContractError::BlockNotFound(height, err.to_string()))?;

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -701,8 +701,12 @@ pub fn compute_active_finality_providers(
         let (filtered, running_total): (Vec<_>, Vec<_>) = batch
             .into_iter()
             .filter(|fp| {
-                // Filter out FPs with no active sats (also includes slashed FPs)
+                // Filter out FPs with no active sats
                 if fp.total_active_sats == 0 {
+                    return false;
+                }
+                // Filter out slashed FPs
+                if fp.slashed {
                     return false;
                 }
                 // Filter out FPs that are jailed.

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -252,7 +252,7 @@ pub fn handle_finality_signature(
     //     this means Babylon will lose safety under an adaptive adversary corrupting even 1
     //     finality provider. It can simply corrupt a new finality provider and equivocate a
     //     historical block over and over again, making a previous block not finalisable forever
-    if fp.slashed_height > 0 {
+    if fp.is_slashed() {
         return Err(ContractError::FinalityProviderAlreadySlashed(
             fp_btc_pk_hex.to_string(),
         ));

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -1,13 +1,12 @@
+use crate::state::config::Params;
+use babylon_apis::finality_api::{Evidence, IndexedBlock};
 use cosmwasm_schema::{cw_serde, QueryResponses};
+use std::collections::HashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use {
     crate::state::config::Config, babylon_apis::finality_api::PubRandCommit,
     cw_controllers::AdminResponse,
 };
-
-use crate::state::config::Params;
-use babylon_apis::finality_api::{Evidence, IndexedBlock};
-use btc_staking::msg::FinalityProviderInfo;
 
 #[cw_serde]
 #[derive(Default)]
@@ -124,5 +123,5 @@ pub struct JailedFinalityProvider {
 
 #[cw_serde]
 pub struct ActiveFinalityProvidersResponse {
-    pub active_finality_providers: Vec<FinalityProviderInfo>,
+    pub active_finality_providers: HashMap<String, u64>,
 }

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -92,6 +92,9 @@ pub enum QueryMsg {
     /// Returns the set of active finality providers at a given height
     #[returns(ActiveFinalityProvidersResponse)]
     ActiveFinalityProviders { height: u64 },
+    /// Returns the voting power of a given finality provider at a given height
+    #[returns(FinalityProviderPowerResponse)]
+    FinalityProviderPower { btc_pk_hex: String, height: u64 },
 }
 
 #[cw_serde]
@@ -124,4 +127,9 @@ pub struct JailedFinalityProvider {
 #[cw_serde]
 pub struct ActiveFinalityProvidersResponse {
     pub active_finality_providers: HashMap<String, u64>,
+}
+
+#[cw_serde]
+pub struct FinalityProviderPowerResponse {
+    pub power: u64,
 }

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -201,9 +201,9 @@ mod finality {
 
         suite.add_delegations(&[del1.clone()]).unwrap();
 
-        // Check that the finality provider power has been updated
+        // Check that the finality provider total active sats has been updated
         let fp_info = suite.get_finality_provider_info(&new_fp.btc_pk_hex, None);
-        assert_eq!(fp_info.power, del1.total_sat);
+        assert_eq!(fp_info.total_active_sats, del1.total_sat);
 
         // Submit public randomness commitment for the FP and the involved heights
         suite
@@ -300,9 +300,9 @@ mod finality {
 
         suite.add_delegations(&[del1.clone()]).unwrap();
 
-        // Check that the finality provider power has been updated
+        // Check that the finality provider total active sats has been updated
         let fp_info = suite.get_finality_provider_info(&new_fp.btc_pk_hex, None);
-        assert_eq!(fp_info.power, del1.total_sat);
+        assert_eq!(fp_info.total_active_sats, del1.total_sat);
 
         // Call the begin-block / end-block sudo handler(s)
         let height = suite.next_block("deadbeef01".as_bytes()).unwrap().height;
@@ -322,7 +322,7 @@ mod finality {
         // Assert the finality provider is now in the active set
         let active_fps = suite.get_active_finality_providers(height);
         assert_eq!(active_fps.len(), 1);
-        assert_eq!(active_fps[0].btc_pk_hex, new_fp.btc_pk_hex.clone(),);
+        assert!(active_fps.contains_key(&new_fp.btc_pk_hex));
     }
 }
 
@@ -370,7 +370,7 @@ mod slashing {
 
         // Check that the finality provider power has been updated
         let fp_info = suite.get_finality_provider_info(&new_fp.btc_pk_hex, None);
-        assert_eq!(fp_info.power, del1.total_sat);
+        assert_eq!(fp_info.total_active_sats, del1.total_sat);
 
         // Submit public randomness commitment for the FP and the involved heights
         suite
@@ -571,7 +571,7 @@ mod jailing {
         let active_fps = suite.get_active_finality_providers(next_height);
         // All unjailed fps are selected
         assert_eq!(active_fps.len(), 1);
-        assert_eq!(active_fps[0].btc_pk_hex, new_fp1.btc_pk_hex.clone(),);
+        assert!(active_fps.contains_key(&new_fp1.btc_pk_hex));
 
         // Moving forward so offline detection kicks in
         suite.advance_seconds(4000).unwrap();
@@ -617,6 +617,6 @@ mod jailing {
         // blocks again
         let active_fps = suite.get_active_finality_providers(next_height);
         assert_eq!(active_fps.len(), 1);
-        assert_eq!(active_fps[0].btc_pk_hex, new_fp1.btc_pk_hex.clone(),);
+        assert!(active_fps.contains_key(&new_fp1.btc_pk_hex));
     }
 }

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -532,4 +532,18 @@ impl Suite {
             .unwrap()
             .active_finality_providers
     }
+
+    pub fn get_finality_provider_power(&self, btc_pk_hex: &str, height: u64) -> u64 {
+        self.app
+            .wrap()
+            .query_wasm_smart::<crate::msg::FinalityProviderPowerResponse>(
+                self.finality.clone(),
+                &crate::msg::QueryMsg::FinalityProviderPower {
+                    btc_pk_hex: btc_pk_hex.to_string(),
+                    height,
+                },
+            )
+            .unwrap()
+            .power
+    }
 }

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result as AnyResult;
 use derivative::Derivative;
 use hex::ToHex;
@@ -519,7 +521,7 @@ impl Suite {
             .jailed_finality_providers
     }
 
-    pub fn get_active_finality_providers(&self, height: u64) -> Vec<FinalityProviderInfo> {
+    pub fn get_active_finality_providers(&self, height: u64) -> HashMap<String, u64> {
         self.app
             .wrap()
             .query_wasm_smart::<ActiveFinalityProvidersResponse>(

--- a/contracts/btc-finality/src/queries.rs
+++ b/contracts/btc-finality/src/queries.rs
@@ -6,8 +6,8 @@ use babylon_apis::finality_api::IndexedBlock;
 
 use crate::error::ContractError;
 use crate::msg::{
-    ActiveFinalityProvidersResponse, BlocksResponse, EvidenceResponse, FinalitySignatureResponse,
-    JailedFinalityProvider, JailedFinalityProvidersResponse,
+    ActiveFinalityProvidersResponse, BlocksResponse, EvidenceResponse, FinalityProviderPowerResponse,
+    FinalitySignatureResponse, JailedFinalityProvider, JailedFinalityProvidersResponse,
 };
 use crate::state::config::{Config, Params};
 use crate::state::config::{CONFIG, PARAMS};
@@ -112,4 +112,15 @@ pub fn active_finality_providers(
     Ok(ActiveFinalityProvidersResponse {
         active_finality_providers: active_fps,
     })
+}
+
+pub fn finality_provider_power(
+    deps: Deps,
+    btc_pk_hex: String,
+    height: u64,
+) -> Result<FinalityProviderPowerResponse, ContractError> {
+    let power_table = get_power_table_at_height(deps.storage, height)?;
+    let power = power_table.get(&btc_pk_hex).copied().unwrap_or(0);
+
+    Ok(FinalityProviderPowerResponse { power })
 }

--- a/contracts/btc-finality/src/queries.rs
+++ b/contracts/btc-finality/src/queries.rs
@@ -11,7 +11,7 @@ use crate::msg::{
 };
 use crate::state::config::{Config, Params};
 use crate::state::config::{CONFIG, PARAMS};
-use crate::state::finality::{BLOCKS, EVIDENCES, FP_SET, JAIL, SIGNATURES};
+use crate::state::finality::{get_power_table_at_height, BLOCKS, EVIDENCES, JAIL, SIGNATURES};
 
 pub fn config(deps: Deps) -> StdResult<Config> {
     CONFIG.load(deps.storage)
@@ -107,7 +107,7 @@ pub fn active_finality_providers(
     deps: Deps,
     height: u64,
 ) -> Result<ActiveFinalityProvidersResponse, ContractError> {
-    let active_fps = FP_SET.may_load(deps.storage, height)?.unwrap_or_default();
+    let active_fps = get_power_table_at_height(deps.storage, height)?;
 
     Ok(ActiveFinalityProvidersResponse {
         active_finality_providers: active_fps,

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -1,3 +1,4 @@
+use crate::error::ContractError;
 use babylon_apis::finality_api::{Evidence, IndexedBlock};
 use cosmwasm_std::Order::Ascending;
 use cosmwasm_std::{StdResult, Storage};
@@ -24,6 +25,21 @@ pub fn get_power_table_at_height(
         .prefix(height)
         .range(storage, None, None, Ascending)
         .collect::<StdResult<HashMap<String, u64>>>()
+}
+
+pub fn ensure_fp_has_power(
+    storage: &mut dyn Storage,
+    height: u64,
+    fp_btc_pk_hex: &str,
+) -> Result<(), ContractError> {
+    let power = FP_POWER_TABLE.may_load(storage, (height, fp_btc_pk_hex))?;
+    if power.is_none() {
+        return Err(ContractError::NoVotingPower(
+            fp_btc_pk_hex.to_string(),
+            height,
+        ));
+    }
+    Ok(())
 }
 
 /// Map of finality providers to block height they initially entered the active set.

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -1,6 +1,8 @@
 use babylon_apis::finality_api::{Evidence, IndexedBlock};
-use btc_staking::msg::FinalityProviderInfo;
+use cosmwasm_std::Order::Ascending;
+use cosmwasm_std::{StdResult, Storage};
 use cw_storage_plus::{Item, Map};
+use std::collections::HashMap;
 
 /// Map of signatures by block height and FP
 pub const SIGNATURES: Map<(u64, &str), Vec<u8>> = Map::new("fp_sigs");
@@ -11,8 +13,18 @@ pub const BLOCKS: Map<u64, IndexedBlock> = Map::new("blocks");
 /// Next height to finalise
 pub const NEXT_HEIGHT: Item<u64> = Item::new("next_height");
 
-/// `FP_SET` is the calculated list of the active finality providers by height
-pub const FP_SET: Map<u64, Vec<FinalityProviderInfo>> = Map::new("fp_set");
+/// `FP_POWER_TABLE` is the map of finality providers to their total active sats at a given height
+pub const FP_POWER_TABLE: Map<(u64, &str), u64> = Map::new("fp_power_table");
+
+pub fn get_power_table_at_height(
+    storage: &dyn Storage,
+    height: u64,
+) -> StdResult<HashMap<String, u64>> {
+    FP_POWER_TABLE
+        .prefix(height)
+        .range(storage, None, None, Ascending)
+        .collect::<StdResult<HashMap<String, u64>>>()
+}
 
 /// Map of finality providers to block height they initially entered the active set.
 /// If an FP isn't in this map, he was not in the active finality provider set,

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -1,11 +1,8 @@
 use crate::error::ContractError;
 use babylon_apis::finality_api::{Evidence, IndexedBlock};
-use babylon_apis::finality_api::{Evidence, IndexedBlock};
-use btc_staking::msg::FinalityProviderInfo;
 use cosmwasm_std::Order::Ascending;
 use cosmwasm_std::Uint128;
 use cosmwasm_std::{StdResult, Storage};
-use cw_storage_plus::{Item, Map};
 use cw_storage_plus::{Item, Map};
 use std::collections::HashMap;
 

--- a/contracts/btc-light-client/src/msg/btc_header.rs
+++ b/contracts/btc-light-client/src/msg/btc_header.rs
@@ -42,6 +42,21 @@ pub struct BtcHeader {
     pub nonce: u32,
 }
 
+impl Default for BtcHeader {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            prev_blockhash: "0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+            merkle_root: "0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+            time: 0,
+            bits: 0,
+            nonce: 0,
+        }
+    }
+}
+
 impl BtcHeader {
     pub fn to_btc_header_info(
         &self,
@@ -198,6 +213,17 @@ pub struct BtcHeaderResponse {
     pub height: u32,
     /// The cumulative total work of this block and all of its ancestors.
     pub cum_work: cosmwasm_std::Uint256,
+}
+
+impl Default for BtcHeaderResponse {
+    fn default() -> Self {
+        Self {
+            header: BtcHeader::default(),
+            hash: String::new(),
+            height: 0,
+            cum_work: cosmwasm_std::Uint256::zero(),
+        }
+    }
 }
 
 /// Bitcoin header responses.

--- a/contracts/btc-staking/src/contract.rs
+++ b/contracts/btc-staking/src/contract.rs
@@ -83,8 +83,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
         QueryMsg::FinalityProviderInfo { btc_pk_hex, height } => Ok(to_json_binary(
             &queries::finality_provider_info(deps, btc_pk_hex, height)?,
         )?),
-        QueryMsg::FinalityProvidersByPower { start_after, limit } => Ok(to_json_binary(
-            &queries::finality_providers_by_power(deps, start_after, limit)?,
+        QueryMsg::FinalityProvidersByTotalActiveSats { start_after, limit } => Ok(to_json_binary(
+            &queries::finality_providers_by_total_active_sats(deps, start_after, limit)?,
         )?),
         QueryMsg::ActivatedHeight {} => Ok(to_json_binary(&queries::activated_height(deps)?)?),
     }

--- a/contracts/btc-staking/src/error.rs
+++ b/contracts/btc-staking/src/error.rs
@@ -60,8 +60,6 @@ pub enum ContractError {
     ErrInvalidLockType,
     #[error("Invalid lock time blocks: {0}, max: {1}")]
     ErrInvalidLockTime(u32, u32),
-    #[error("The finality provider {0} does not have voting power at height {1}")]
-    NoVotingPower(String, u64),
     #[error("The chain has not reached the given height yet")]
     HeightTooHigh,
     #[error("The finality provider {0} signed two different blocks at height {1}")]

--- a/contracts/btc-staking/src/msg.rs
+++ b/contracts/btc-staking/src/msg.rs
@@ -74,9 +74,9 @@ pub enum QueryMsg {
         /// If `height` is not provided, the latest aggregated power is returned
         height: Option<u64>,
     },
-    /// Returns the list of finality provider infos sorted by their aggregated power, in descending order.
-    #[returns(FinalityProvidersByPowerResponse)]
-    FinalityProvidersByPower {
+    /// Returns the list of finality provider infos sorted by their total active sats, in descending order.
+    #[returns(FinalityProvidersByTotalActiveSatsResponse)]
+    FinalityProvidersByTotalActiveSats {
         /// BTC public key of the FP to start after, or `None` to start from the top
         start_after: Option<FinalityProviderInfo>,
         limit: Option<u32>,
@@ -102,7 +102,7 @@ pub struct DelegationsByFPResponse {
 }
 
 #[cw_serde]
-pub struct FinalityProvidersByPowerResponse {
+pub struct FinalityProvidersByTotalActiveSatsResponse {
     pub fps: Vec<FinalityProviderInfo>,
 }
 
@@ -111,9 +111,8 @@ pub struct FinalityProviderInfo {
     /// Bitcoin secp256k1 PK of this finality provider.
     /// The PK follows encoding in BIP-340 spec in hex format
     pub btc_pk_hex: String,
-    /// Aggregated power of this finality provider.
-    /// The power is calculated based on the amount of BTC delegated to this finality provider
-    pub power: u64,
+    /// Total active sats delegated to this finality provider
+    pub total_active_sats: u64,
 }
 
 #[cw_serde]

--- a/contracts/btc-staking/src/msg.rs
+++ b/contracts/btc-staking/src/msg.rs
@@ -113,6 +113,8 @@ pub struct FinalityProviderInfo {
     pub btc_pk_hex: String,
     /// Total active sats delegated to this finality provider
     pub total_active_sats: u64,
+    /// Whether this finality provider is slashed
+    pub slashed: bool,
 }
 
 #[cw_serde]

--- a/contracts/btc-staking/src/staking.rs
+++ b/contracts/btc-staking/src/staking.rs
@@ -481,7 +481,7 @@ fn slash_finality_provider(
     }
     // Set the finality provider as slashed
     fp.slashed_height = env.block.height;
-    fp.slashed_btc_height = get_btc_tip_height(&deps)?;
+    fp.slashed_btc_height = get_btc_tip_height(&deps).unwrap_or_default();
 
     // Record slashed event. The next `BeginBlock` will consume this event for updating the active
     // FP set. We simply set the FP total active sats to zero from the next *processing* height

--- a/contracts/btc-staking/src/state/fp_index.rs
+++ b/contracts/btc-staking/src/state/fp_index.rs
@@ -1,7 +1,6 @@
 // Adapted from Tgrade's poe-contracts/packages/utils/src/member_indexes.rs
-use cw_storage_plus::{Index, IndexList, MultiIndex};
-
 use crate::state::staking::FinalityProviderState;
+use cw_storage_plus::{Index, IndexList, MultiIndex};
 
 pub struct FinalityProviderIndexes<'a> {
     // Power (multi-)index (deserializing the (hidden) pk to String)

--- a/contracts/btc-staking/src/state/staking.rs
+++ b/contracts/btc-staking/src/state/staking.rs
@@ -1,5 +1,4 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Uint256;
 use cw_storage_plus::{IndexedSnapshotMap, Item, Map, MultiIndex, Strategy};
 use k256::schnorr::SigningKey;
 
@@ -50,7 +49,11 @@ pub const ACTIVATED_HEIGHT: Item<u64> = Item::new("activated_height");
 pub fn fps<'a>() -> IndexedSnapshotMap<&'a str, FinalityProviderState, FinalityProviderIndexes<'a>>
 {
     let indexes = FinalityProviderIndexes {
-        power: MultiIndex::new(|_, fp_state| fp_state.power, FP_STATE_KEY, FP_POWER_KEY),
+        power: MultiIndex::new(
+            |_, fp_state| fp_state.total_active_sats,
+            FP_STATE_KEY,
+            FP_POWER_KEY,
+        ),
     };
     IndexedSnapshotMap::new(
         FP_STATE_KEY,
@@ -64,18 +67,8 @@ pub fn fps<'a>() -> IndexedSnapshotMap<&'a str, FinalityProviderState, FinalityP
 #[cw_serde]
 #[derive(Default)]
 pub struct FinalityProviderState {
-    /// Finality provider power, in satoshis.
-    /// Total satoshis delegated to this finality provider by all users
-    //TODO?: Rename to `total_delegation`
-    pub power: u64,
-    /// Points user is eligible to by single token delegation
-    //TODO?: Rename to `delegation_points`
-    //TODO: Use Uint128 (similar to #123)
-    pub points_per_stake: Uint256,
-    /// Points which were not distributed previously
-    //TODO?: Rename to `leftover_points`
-    //TODO: Use Uint128 (similar to #123)
-    pub points_leftover: Uint256,
+    /// Total active sats delegated to this finality provider
+    pub total_active_sats: u64,
 }
 
 #[cw_serde]

--- a/contracts/btc-staking/src/state/staking.rs
+++ b/contracts/btc-staking/src/state/staking.rs
@@ -46,8 +46,8 @@ pub const ACTIVATED_HEIGHT: Item<u64> = Item::new("activated_height");
 /// The power index is a `MultiIndex`, as there can be multiple FPs with the same power.
 ///
 /// The indexes are not snapshotted; only the current power is indexed at any given time.
-pub fn fps<'a>() -> IndexedSnapshotMap<&'a str, FinalityProviderState, FinalityProviderIndexes<'a>>
-{
+pub fn get_fp_state_map<'a>(
+) -> IndexedSnapshotMap<&'a str, FinalityProviderState, FinalityProviderIndexes<'a>> {
     let indexes = FinalityProviderIndexes {
         power: MultiIndex::new(
             |_, fp_state| fp_state.total_active_sats,
@@ -69,6 +69,8 @@ pub fn fps<'a>() -> IndexedSnapshotMap<&'a str, FinalityProviderState, FinalityP
 pub struct FinalityProviderState {
     /// Total active sats delegated to this finality provider
     pub total_active_sats: u64,
+    /// Whether this finality provider is slashed
+    pub slashed: bool,
 }
 
 #[cw_serde]

--- a/packages/apis/src/btc_staking_api.rs
+++ b/packages/apis/src/btc_staking_api.rs
@@ -102,6 +102,12 @@ pub struct FinalityProvider {
     pub consumer_id: String,
 }
 
+impl FinalityProvider {
+    pub fn is_slashed(&self) -> bool {
+        self.slashed_height > 0 || self.slashed_btc_height > 0
+    }
+}
+
 impl From<&NewFinalityProvider> for FinalityProvider {
     fn from(new_fp: &NewFinalityProvider) -> Self {
         FinalityProvider {


### PR DESCRIPTION
Resolves #156 

This PR fixes the voting power table bugs. This includes

- [x] replacing voting power with total active sat in BTC staking contract. Now BTC staking contract is only tracking total active sat and slashing status for each FP
- [x] refactoring `compute_active_finality_providers` in BTC finality contract such that it maintains the voting power table internally
- [x] `compute_active_finality_providers` now excludes FPs that do not have BTC timestamps, are slashed, are jailed, or have 0 total active sat
- [x] BTC finality contract now uses its internal voting power table for handling finality signatures and tallying
- [x] adding a query for FP voting power in BTC finality contract
- [x] adding unit tests in BTC staking contract