### PR TITLE
finality: handle finality signature misalignment (part-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#285](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/285) finality: return error on the duplicated finality vote
 - [#282](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/282) finality: introduce `AddFinalitySig` and add `validate_basic()` check
 - [#281](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/281) chore: Cleanup unused dependencies and enforce dependency check in CI
 - [#270](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/270) fix: fix Babylon SDK e2e

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -152,7 +152,7 @@ pub fn execute(
         } => handle_finality_signature(
             deps,
             env,
-            crate::finality::AddFinalitySigMsg {
+            crate::finality::MsgAddFinalitySig {
                 fp_btc_pk_hex: fp_pubkey_hex,
                 height,
                 pub_rand: pub_rand.into(),
@@ -170,7 +170,7 @@ pub fn execute(
         } => handle_public_randomness_commit(
             deps,
             &env,
-            crate::finality::PublicRandomnessCommitMsg {
+            crate::finality::MsgCommitPubRand {
                 fp_btc_pk_hex: fp_pubkey_hex,
                 start_height,
                 num_pub_rand,

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -244,8 +244,8 @@ pub enum FinalitySigError {
     InvalidFinalitySigLength { actual: usize, expected: usize },
     #[error("invalid block app hash length: got {actual}, want {expected}")]
     InvalidBlockAppHashLength { actual: usize, expected: usize },
-    #[error("duplicate finality vote")]
-    DuplicatedCovenantSig,
+    #[error("duplicated finality vote")]
+    DuplicatedFinalitySig,
     #[error(transparent)]
     Hex(#[from] hex::FromHexError),
 }
@@ -405,7 +405,8 @@ pub fn handle_finality_signature(
             deps.api.debug(&format!("Received duplicated finality vote. Height: {height}, Finality Provider: {fp_btc_pk_hex}"));
             // Exactly the same vote already exists, return success to the provider
             // While there is no tx refunding in the contract, an error is still returned for consistency.
-            return Err(FinalitySigError::DuplicatedCovenantSig.into());
+            // https://github.com/babylonlabs-io/babylon/blob/80d89b10add5d914f2a7353b725b803b17fb7cc5/x/finality/keeper/msg_server.go#L131
+            return Err(FinalitySigError::DuplicatedFinalitySig.into());
         }
         _ => {}
     }

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -42,6 +42,10 @@ const SCHNORR_EOTS_SIG_LEN: usize = 32;
 // Tendermint hash size (SHA256)
 const TMHASH_SIZE: usize = 32;
 
+const QUERY_LIMIT: Option<u32> = Some(30);
+
+pub const JAIL_FOREVER: u64 = 0;
+
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum PubRandCommitError {
     #[error("Empty FP BTC PubKey")]
@@ -498,8 +502,6 @@ pub fn handle_finality_signature(
     Ok(res)
 }
 
-pub const JAIL_FOREVER: u64 = 0;
-
 pub fn handle_unjail(
     deps: DepsMut,
     env: &Env,
@@ -755,8 +757,6 @@ fn finalize_block(
         .add_attribute("finalized_height", block.height.to_string());
     Ok(ev)
 }
-
-const QUERY_LIMIT: Option<u32> = Some(30);
 
 /// Sorts all finality providers, counts the total voting power of top finality providers, and records them
 /// in the contract state.

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -240,6 +240,8 @@ pub enum FinalitySigError {
     InvalidFinalitySigLength { actual: usize, expected: usize },
     #[error("invalid block app hash length: got {actual}, want {expected}")]
     InvalidBlockAppHashLength { actual: usize, expected: usize },
+    #[error("duplicate finality vote")]
+    DuplicatedCovenantSig,
     #[error(transparent)]
     Hex(#[from] hex::FromHexError),
 }
@@ -364,7 +366,8 @@ pub fn handle_finality_signature(
         Some(existing_sig) if existing_sig == signature => {
             deps.api.debug(&format!("Received duplicated finality vote. Height: {height}, Finality Provider: {fp_btc_pk_hex}"));
             // Exactly the same vote already exists, return success to the provider
-            return Ok(Response::new());
+            // While there is no tx refunding in the contract, an error is still returned for consistency.
+            return Err(FinalitySigError::DuplicatedCovenantSig.into());
         }
         _ => {}
     }

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -724,7 +724,7 @@ pub fn tally_blocks(
 
 /// Checks whether a block with the given finality provider set and votes reaches a quorum or not.
 fn tally(fp_power_table: &HashMap<String, u64>, voters: &[String]) -> bool {
-    let voters: HashSet<String> = voters.iter().cloned().collect();
+    let voters: HashSet<_> = voters.iter().collect();
     let mut total_power = 0;
     let mut voted_power = 0;
     for (fp_btc_pk_hex, power) in fp_power_table {

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -59,7 +59,7 @@ pub enum PubRandCommitError {
 }
 
 // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/tx.pb.go#L36
-pub struct PublicRandomnessCommitMsg {
+pub struct MsgCommitPubRand {
     pub fp_btc_pk_hex: String,
     pub start_height: u64,
     pub num_pub_rand: u64,
@@ -67,7 +67,7 @@ pub struct PublicRandomnessCommitMsg {
     pub sig: Vec<u8>,
 }
 
-impl PublicRandomnessCommitMsg {
+impl MsgCommitPubRand {
     // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg.go#L161
     fn validate_basic(&self) -> Result<(), PubRandCommitError> {
         if self.fp_btc_pk_hex.is_empty() {
@@ -138,7 +138,7 @@ impl PublicRandomnessCommitMsg {
 pub fn handle_public_randomness_commit(
     deps: DepsMut,
     env: &Env,
-    pub_rand_commit: PublicRandomnessCommitMsg,
+    pub_rand_commit: MsgCommitPubRand,
 ) -> Result<Response, ContractError> {
     pub_rand_commit.validate_basic()?;
 
@@ -251,7 +251,7 @@ pub enum FinalitySigError {
 }
 
 // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/tx.pb.go#L154
-pub struct AddFinalitySigMsg {
+pub struct MsgAddFinalitySig {
     pub fp_btc_pk_hex: String,
     pub height: u64,
     pub pub_rand: Vec<u8>,
@@ -260,7 +260,7 @@ pub struct AddFinalitySigMsg {
     pub signature: Vec<u8>,
 }
 
-impl AddFinalitySigMsg {
+impl MsgAddFinalitySig {
     // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg.go#L40
     fn validate_basic(&self) -> Result<(), FinalitySigError> {
         // Validate FP BTC PubKey
@@ -308,7 +308,6 @@ impl AddFinalitySigMsg {
 
     /// Verifies the finality signature message w.r.t. the public randomness commitment:
     /// - Public randomness inclusion proof.
-    /// - Finality signature
     fn verify_finality_signature(
         &self,
         pr_commit: &PubRandCommit,
@@ -351,7 +350,7 @@ impl AddFinalitySigMsg {
 pub fn handle_finality_signature(
     mut deps: DepsMut,
     env: Env,
-    add_finality_sig: AddFinalitySigMsg,
+    add_finality_sig: MsgAddFinalitySig,
 ) -> Result<Response, ContractError> {
     add_finality_sig.validate_basic()?;
 
@@ -422,7 +421,7 @@ pub fn handle_finality_signature(
 
     add_finality_sig.verify_finality_signature(&pr_commit, &signing_context)?;
 
-    let AddFinalitySigMsg {
+    let MsgAddFinalitySig {
         fp_btc_pk_hex,
         height,
         pub_rand,
@@ -956,7 +955,7 @@ mod tests {
 
         struct TestCase {
             name: &'static str,
-            msg_modifier: fn(&mut AddFinalitySigMsg),
+            msg_modifier: fn(&mut MsgAddFinalitySig),
             expected: Result<(), FinalitySigError>,
         }
 
@@ -1037,7 +1036,7 @@ mod tests {
         } in test_cases
         {
             // Create a valid message
-            let mut msg = AddFinalitySigMsg {
+            let mut msg = MsgAddFinalitySig {
                 fp_btc_pk_hex: hex::encode(gen_random_bytes(&mut rng, BIP340_PUB_KEY_LEN)),
                 height: rng.gen_range(1..1000),
                 pub_rand: gen_random_bytes(&mut rng, SCHNORR_PUB_RAND_LEN),

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -452,8 +452,8 @@ mod slashing {
             )
             .unwrap();
 
-        // Submitting the same signature twice is tolerated
-        suite
+        // Submitting the same signature twice is not allowed.
+        assert!(suite
             .submit_finality_signature(
                 &pk_hex,
                 submit_height,
@@ -462,7 +462,7 @@ mod slashing {
                 &add_finality_signature.block_app_hash,
                 &finality_signature,
             )
-            .unwrap();
+            .is_err());
 
         // Submit another (different and valid) finality signature, from the same finality provider
         // at the same height, and with the same proof


### PR DESCRIPTION
This PR is primarily a refactor, with one exception: we now return an error on duplicated finality votes, as discussed in #263.

Main points:
- Eliminated several unnecessary allocations for efficiency.
- Renamed types to `MsgCommitPubRand` and `MsgAddFinalitySig` for clarity and consistency. (`MsgCommitPubRandList` felt a bit awkward, but happy to reconsider if there's a strong preference.)

Part of #263