### PR TITLE
finality: add missing finality queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#290](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/290) finality: add missing queries
 - [#287](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/285) refactor: simplify finality Error type
 - [#286](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/286) fix: ICS-20 transfer memo format
 - [#285](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/285) finality: return error on the duplicated finality vote

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -121,6 +121,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
             &queries::finality_provider_power(deps, btc_pk_hex, height)?,
         )?),
         QueryMsg::Votes { height } => Ok(to_json_binary(&queries::votes(deps, height)?)?),
+        QueryMsg::SigningInfo { btc_pk_hex } => {
+            Ok(to_json_binary(&queries::signing_info(deps, btc_pk_hex)?)?)
+        }
     }
 }
 

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -120,6 +120,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
         QueryMsg::FinalityProviderPower { btc_pk_hex, height } => Ok(to_json_binary(
             &queries::finality_provider_power(deps, btc_pk_hex, height)?,
         )?),
+        QueryMsg::Votes { height } => Ok(to_json_binary(&queries::votes(deps, height)?)?),
     }
 }
 

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -98,6 +98,9 @@ pub enum QueryMsg {
     /// Returns the finality providers who have signed the block at given height.
     #[returns(VotesResponse)]
     Votes { height: u64 },
+    /// Returns the signing info of a finality provider if any.
+    #[returns(Option<SigningInfoRepsonse>)]
+    SigningInfo { btc_pk_hex: String },
 }
 
 #[cw_serde]
@@ -146,6 +149,6 @@ pub struct VotesResponse {
 pub struct SigningInfoRepsonse {
     pub fp_btc_pk_hex: String,
     pub start_height: u64,
-    pub missed_blocks_counter: u64,
-    pub jailed_until: u64,
+    pub last_signed_height: u64,
+    pub jailed_until: Option<u64>,
 }

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -99,7 +99,7 @@ pub enum QueryMsg {
     #[returns(VotesResponse)]
     Votes { height: u64 },
     /// Returns the signing info of a finality provider if any.
-    #[returns(Option<SigningInfoRepsonse>)]
+    #[returns(Option<SigningInfoResponse>)]
     SigningInfo { btc_pk_hex: String },
 }
 
@@ -146,7 +146,7 @@ pub struct VotesResponse {
 }
 
 #[cw_serde]
-pub struct SigningInfoRepsonse {
+pub struct SigningInfoResponse {
     pub fp_btc_pk_hex: String,
     pub start_height: u64,
     pub last_signed_height: u64,

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -95,6 +95,9 @@ pub enum QueryMsg {
     /// Returns the voting power of a given finality provider at a given height
     #[returns(FinalityProviderPowerResponse)]
     FinalityProviderPower { btc_pk_hex: String, height: u64 },
+    /// Returns the finality providers who have signed the block at given height.
+    #[returns(VotesResponse)]
+    Votes { height: u64 },
 }
 
 #[cw_serde]
@@ -132,4 +135,9 @@ pub struct ActiveFinalityProvidersResponse {
 #[cw_serde]
 pub struct FinalityProviderPowerResponse {
     pub power: u64,
+}
+
+#[cw_serde]
+pub struct VotesResponse {
+    pub btc_pks: Vec<String>,
 }

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -141,3 +141,11 @@ pub struct FinalityProviderPowerResponse {
 pub struct VotesResponse {
     pub btc_pks: Vec<String>,
 }
+
+#[cw_serde]
+pub struct SigningInfoRepsonse {
+    pub fp_btc_pk_hex: String,
+    pub start_height: u64,
+    pub missed_blocks_counter: u64,
+    pub jailed_until: u64,
+}

--- a/contracts/btc-finality/src/queries.rs
+++ b/contracts/btc-finality/src/queries.rs
@@ -2,7 +2,7 @@ use crate::error::ContractError;
 use crate::msg::{
     ActiveFinalityProvidersResponse, BlocksResponse, EvidenceResponse,
     FinalityProviderPowerResponse, FinalitySignatureResponse, JailedFinalityProvider,
-    JailedFinalityProvidersResponse, SigningInfoRepsonse, VotesResponse,
+    JailedFinalityProvidersResponse, SigningInfoResponse, VotesResponse,
 };
 use crate::state::finality::{
     get_last_signed_height, get_power_table_at_height, BLOCKS, EVIDENCES, FP_START_HEIGHT, JAIL,
@@ -128,7 +128,7 @@ pub fn votes(deps: Deps, height: u64) -> Result<VotesResponse, ContractError> {
 pub fn signing_info(
     deps: Deps,
     fp_btc_pk_hex: String,
-) -> Result<Option<SigningInfoRepsonse>, ContractError> {
+) -> Result<Option<SigningInfoResponse>, ContractError> {
     let Some(start_height) = FP_START_HEIGHT.may_load(deps.storage, &fp_btc_pk_hex)? else {
         // Can not find the FP entry for the given fp_btc_pk_hex.
         return Ok(None);
@@ -136,7 +136,7 @@ pub fn signing_info(
     let last_signed_height = get_last_signed_height(deps.storage, &fp_btc_pk_hex)?
         .expect("Must be Some as start_height exists");
     let jailed_until = JAIL.may_load(deps.storage, &fp_btc_pk_hex)?;
-    Ok(Some(SigningInfoRepsonse {
+    Ok(Some(SigningInfoResponse {
         fp_btc_pk_hex,
         start_height,
         last_signed_height,

--- a/contracts/btc-finality/src/queries.rs
+++ b/contracts/btc-finality/src/queries.rs
@@ -2,7 +2,7 @@ use crate::error::ContractError;
 use crate::msg::{
     ActiveFinalityProvidersResponse, BlocksResponse, EvidenceResponse,
     FinalityProviderPowerResponse, FinalitySignatureResponse, JailedFinalityProvider,
-    JailedFinalityProvidersResponse,
+    JailedFinalityProvidersResponse, VotesResponse,
 };
 use crate::state::finality::{get_power_table_at_height, BLOCKS, EVIDENCES, JAIL, SIGNATURES};
 use babylon_apis::finality_api::IndexedBlock;
@@ -112,4 +112,12 @@ pub fn finality_provider_power(
     let power = power_table.get(&btc_pk_hex).copied().unwrap_or(0);
 
     Ok(FinalityProviderPowerResponse { power })
+}
+
+pub fn votes(deps: Deps, height: u64) -> Result<VotesResponse, ContractError> {
+    let btc_pks = SIGNATURES
+        .prefix(height)
+        .keys(deps.storage, None, None, Ascending)
+        .collect::<StdResult<Vec<_>>>()?;
+    Ok(VotesResponse { btc_pks })
 }

--- a/contracts/btc-finality/src/queries.rs
+++ b/contracts/btc-finality/src/queries.rs
@@ -2,9 +2,12 @@ use crate::error::ContractError;
 use crate::msg::{
     ActiveFinalityProvidersResponse, BlocksResponse, EvidenceResponse,
     FinalityProviderPowerResponse, FinalitySignatureResponse, JailedFinalityProvider,
-    JailedFinalityProvidersResponse, VotesResponse,
+    JailedFinalityProvidersResponse, SigningInfoRepsonse, VotesResponse,
 };
-use crate::state::finality::{get_power_table_at_height, BLOCKS, EVIDENCES, JAIL, SIGNATURES};
+use crate::state::finality::{
+    get_last_signed_height, get_power_table_at_height, BLOCKS, EVIDENCES, FP_START_HEIGHT, JAIL,
+    SIGNATURES,
+};
 use babylon_apis::finality_api::IndexedBlock;
 use cosmwasm_std::Order::{Ascending, Descending};
 use cosmwasm_std::{Deps, StdResult};
@@ -122,6 +125,21 @@ pub fn votes(deps: Deps, height: u64) -> Result<VotesResponse, ContractError> {
     Ok(VotesResponse { btc_pks })
 }
 
-pub fn signing_info(deps: Deps, btc_pk_hex: String) -> Result<SigningInfoRepsonse, ContractError> {
-    todo!()
+pub fn signing_info(
+    deps: Deps,
+    fp_btc_pk_hex: String,
+) -> Result<Option<SigningInfoRepsonse>, ContractError> {
+    let Some(start_height) = FP_START_HEIGHT.may_load(deps.storage, &fp_btc_pk_hex)? else {
+        // Can not find the FP entry for the given fp_btc_pk_hex.
+        return Ok(None);
+    };
+    let last_signed_height = get_last_signed_height(deps.storage, &fp_btc_pk_hex)?
+        .expect("Must be Some as start_height exists");
+    let jailed_until = JAIL.may_load(deps.storage, &fp_btc_pk_hex)?;
+    Ok(Some(SigningInfoRepsonse {
+        fp_btc_pk_hex,
+        start_height,
+        last_signed_height,
+        jailed_until,
+    }))
 }

--- a/contracts/btc-finality/src/queries.rs
+++ b/contracts/btc-finality/src/queries.rs
@@ -121,3 +121,7 @@ pub fn votes(deps: Deps, height: u64) -> Result<VotesResponse, ContractError> {
         .collect::<StdResult<Vec<_>>>()?;
     Ok(VotesResponse { btc_pks })
 }
+
+pub fn signing_info(deps: Deps, btc_pk_hex: String) -> Result<SigningInfoRepsonse, ContractError> {
+    todo!()
+}

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -18,6 +18,30 @@ pub const NEXT_HEIGHT: Item<u64> = Item::new("next_height");
 /// `FP_POWER_TABLE` is the map of finality providers to their total active sats at a given height
 pub const FP_POWER_TABLE: Map<(u64, &str), u64> = Map::new("fp_power_table");
 
+/// Map of finality providers to block height they initially entered the active set.
+/// If an FP isn't in this map, he was not in the active finality provider set,
+/// since forever, or since its latest unjailing.
+pub const FP_START_HEIGHT: Map<&str, u64> = Map::new("start_height");
+
+/// Map of finality providers to block heights they had last signed a block,
+/// since the beginning, or since their last unjailing.
+pub const FP_BLOCK_SIGNER: Map<&str, u64> = Map::new("block_signer");
+
+/// Map of jailed FPs to jail expiration time.
+/// If an FP doesn't appear in this map, it is not jailed.
+/// The value is the time in seconds since UNIX epoch when the FP will be released from jail.
+/// If it's zero, the FP will be jailed forever.
+pub const JAIL: Map<&str, u64> = Map::new("jail");
+
+/// Map of double signing evidence by FP and block height
+pub const EVIDENCES: Map<(&str, u64), Evidence> = Map::new("evidences");
+
+/// Map of pending finality provider rewards
+pub const REWARDS: Map<&str, Uint128> = Map::new("rewards");
+
+/// Total pending rewards
+pub const TOTAL_PENDING_REWARDS: Item<Uint128> = Item::new("pending_rewards");
+
 pub fn get_power_table_at_height(
     storage: &dyn Storage,
     height: u64,
@@ -42,27 +66,3 @@ pub fn ensure_fp_has_power(
     }
     Ok(())
 }
-
-/// Map of finality providers to block height they initially entered the active set.
-/// If an FP isn't in this map, he was not in the active finality provider set,
-/// since forever, or since its latest unjailing.
-pub const FP_START_HEIGHT: Map<&str, u64> = Map::new("start_height");
-
-/// Map of finality providers to block heights they had last signed a block,
-/// since the beginning, or since their last unjailing.
-pub const FP_BLOCK_SIGNER: Map<&str, u64> = Map::new("block_signer");
-
-/// Map of jailed FPs to jail expiration time.
-/// If an FP doesn't appear in this map, it is not jailed.
-/// The value is the time in seconds since UNIX epoch when the FP will be released from jail.
-/// If it's zero, the FP will be jailed forever.
-pub const JAIL: Map<&str, u64> = Map::new("jail");
-
-/// Map of double signing evidence by FP and block height
-pub const EVIDENCES: Map<(&str, u64), Evidence> = Map::new("evidences");
-
-/// Map of pending finality provider rewards
-pub const REWARDS: Map<&str, Uint128> = Map::new("rewards");
-
-/// Total pending rewards
-pub const TOTAL_PENDING_REWARDS: Item<Uint128> = Item::new("pending_rewards");

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -71,11 +71,11 @@ pub fn get_last_signed_height(
     storage: &dyn Storage,
     fp_btc_pk_hex: &str,
 ) -> cosmwasm_std::StdResult<Option<u64>> {
-    let mut last_sign_height = FP_BLOCK_SIGNER.may_load(storage, fp_btc_pk_hex)?;
-    if last_sign_height.is_none() {
-        // Not a block signer yet, check their start height instead
-        last_sign_height = FP_START_HEIGHT.may_load(storage, fp_btc_pk_hex)?;
+    match FP_BLOCK_SIGNER.may_load(storage, fp_btc_pk_hex)? {
+        Some(v) => Ok(Some(v)),
+        None => {
+            // Not a block signer yet, check their start height instead
+            FP_START_HEIGHT.may_load(storage, fp_btc_pk_hex)
+        }
     }
-
-    Ok(last_sign_height)
 }

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -66,3 +66,16 @@ pub fn ensure_fp_has_power(
     }
     Ok(())
 }
+
+pub fn get_last_signed_height(
+    storage: &dyn Storage,
+    fp_btc_pk_hex: &str,
+) -> cosmwasm_std::StdResult<Option<u64>> {
+    let mut last_sign_height = FP_BLOCK_SIGNER.may_load(storage, fp_btc_pk_hex)?;
+    if last_sign_height.is_none() {
+        // Not a block signer yet, check their start height instead
+        last_sign_height = FP_START_HEIGHT.may_load(storage, fp_btc_pk_hex)?;
+    }
+
+    Ok(last_sign_height)
+}


### PR DESCRIPTION
I'm not confident that the `signing_info()` query semantically aligns with the existing ones. Please take a closer look.

Close #269