### PR TITLE
finality: move activated height from BTC staking contract to BTC finality contract

### DIFF
--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -3,7 +3,7 @@ use crate::finality::{
     compute_active_finality_providers, distribute_rewards_fps, handle_finality_signature,
     handle_public_randomness_commit, handle_unjail,
 };
-use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::msg::{ActivatedHeightResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state::config::{
     Config, ADMIN, CONFIG, DEFAULT_JAIL_DURATION, DEFAULT_MAX_ACTIVE_FINALITY_PROVIDERS,
     DEFAULT_MIN_PUB_RAND, DEFAULT_MISSED_BLOCKS_WINDOW, DEFAULT_REWARD_INTERVAL,
@@ -121,6 +121,16 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
         QueryMsg::Votes { height } => Ok(to_json_binary(&queries::votes(deps, height)?)?),
         QueryMsg::SigningInfo { btc_pk_hex } => {
             Ok(to_json_binary(&queries::signing_info(deps, btc_pk_hex)?)?)
+        }
+        QueryMsg::ActivatedHeight {} => {
+            let (activated, activated_height) = get_btc_staking_activated_height(deps.storage);
+            if activated {
+                Ok(to_json_binary(&ActivatedHeightResponse {
+                    height: activated_height,
+                })?)
+            } else {
+                Err(ContractError::BTCStakingNotActivated)
+            }
         }
     }
 }

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -8,17 +8,15 @@ use crate::state::config::{
     Config, ADMIN, CONFIG, DEFAULT_JAIL_DURATION, DEFAULT_MAX_ACTIVE_FINALITY_PROVIDERS,
     DEFAULT_MIN_PUB_RAND, DEFAULT_MISSED_BLOCKS_WINDOW, DEFAULT_REWARD_INTERVAL,
 };
-use crate::state::finality::{REWARDS, TOTAL_PENDING_REWARDS};
+use crate::state::finality::{get_btc_staking_activated_height, REWARDS, TOTAL_PENDING_REWARDS};
 use crate::{finality, queries, state};
 use babylon_apis::finality_api::SudoMsg;
 use babylon_contract::msg::contract::RewardInfo;
-use btc_staking::msg::ActivatedHeightResponse;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     attr, coins, to_json_binary, Addr, CustomQuery, Deps, DepsMut, Empty, Env, MessageInfo, Order,
-    QuerierWrapper, QueryRequest, QueryResponse, Reply, Response, StdResult, Uint128, WasmMsg,
-    WasmQuery,
+    QueryRequest, QueryResponse, Reply, Response, StdResult, Uint128, WasmMsg, WasmQuery,
 };
 use cw2::set_contract_version;
 use cw_utils::{maybe_addr, nonpayable};
@@ -239,17 +237,23 @@ fn handle_end_block(
     // finality provider has voting power, start indexing and tallying blocks
     let cfg = CONFIG.load(deps.storage)?;
     let mut res = Response::new();
-    let activated_height = get_activated_height(&cfg.staking, &deps.querier)?;
-    if activated_height > 0 {
-        // Index the current block
-        let ev = finality::index_block(deps, env.block.height, &hex::decode(app_hash_hex)?)?;
-        res = res.add_event(ev);
-        // Tally all non-finalised blocks
-        let events = finality::tally_blocks(deps, &env, activated_height)?;
-        res = res.add_events(events);
+
+    let (activated, activated_height) = get_btc_staking_activated_height(deps.storage);
+
+    // If the BTC staking protocol is not activated, do nothing
+    if !activated {
+        return Ok(res);
     }
 
-    // On an epoch boundary, send rewards for distribution to Babylon Genesis
+    // Index the current block
+    let ev = finality::index_block(deps, env.block.height, &hex::decode(app_hash_hex)?)?;
+    res = res.add_event(ev);
+
+    // Tally all non-finalised blocks
+    let events = finality::tally_blocks(deps, &env, activated_height)?;
+    res = res.add_events(events);
+
+    // On an reward interval boundary, send rewards for distribution to Babylon Genesis
     if env.block.height > 0 && env.block.height % cfg.reward_interval == 0 {
         let rewards = TOTAL_PENDING_REWARDS.load(deps.storage)?;
         if rewards.u128() > 0 {
@@ -263,6 +267,7 @@ fn handle_end_block(
             TOTAL_PENDING_REWARDS.save(deps.storage, &Uint128::zero())?;
         }
     }
+
     Ok(res)
 }
 
@@ -300,16 +305,6 @@ fn send_rewards_msg(
         funds: coins(rewards, cfg.denom.as_str()),
     };
     Ok((fp_rewards, wasm_msg))
-}
-
-pub fn get_activated_height(staking_addr: &Addr, querier: &QuerierWrapper) -> StdResult<u64> {
-    // TODO: Use a raw query (#41)
-    let query = encode_smart_query(
-        staking_addr,
-        &btc_staking::msg::QueryMsg::ActivatedHeight {},
-    )?;
-    let res: ActivatedHeightResponse = querier.query(&query)?;
-    Ok(res.height)
 }
 
 pub(crate) fn encode_smart_query<Q: CustomQuery>(

--- a/contracts/btc-finality/src/error.rs
+++ b/contracts/btc-finality/src/error.rs
@@ -20,6 +20,8 @@ pub enum ContractError {
     Unauthorized,
     #[error("Finality provider not found: {0}")]
     FinalityProviderNotFound(String),
+    #[error("The BTC staking protocol is not activated yet")]
+    BTCStakingNotActivated,
     #[error("The finality provider {0} does not have voting power at height {1}")]
     NoVotingPower(String, u64),
     #[error("The chain has not reached the given height yet")]

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -82,7 +82,6 @@ pub enum QueryMsg {
     /// Returns the evidence for a given FP and block height.
     #[returns(EvidenceResponse)]
     Evidence { btc_pk_hex: String, height: u64 },
-
     /// Returns the list of jailed finality providers
     #[returns(JailedFinalityProvidersResponse)]
     JailedFinalityProviders {
@@ -95,6 +94,9 @@ pub enum QueryMsg {
     /// Returns the voting power of a given finality provider at a given height
     #[returns(FinalityProviderPowerResponse)]
     FinalityProviderPower { btc_pk_hex: String, height: u64 },
+    /// Returns the activated height of the BTC staking protocol
+    #[returns(ActivatedHeightResponse)]
+    ActivatedHeight {},
     /// Returns the finality providers who have signed the block at given height.
     #[returns(VotesResponse)]
     Votes { height: u64 },
@@ -151,4 +153,9 @@ pub struct SigningInfoResponse {
     pub start_height: u64,
     pub last_signed_height: u64,
     pub jailed_until: Option<u64>,
+}
+
+#[cw_serde]
+pub struct ActivatedHeightResponse {
+    pub height: u64,
 }

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -102,19 +102,11 @@ mod finality {
 
         suite.register_finality_providers(&[new_fp]).unwrap();
 
-        // Activated height is not set
-        let res = suite.get_activated_height();
-        assert_eq!(res.height, 0);
-
         // Add a delegation, so that the finality provider has some power
         let mut del1 = get_derived_btc_delegation(1, &[1]);
         del1.fp_btc_pk_list = vec![pk_hex.clone()];
 
         suite.add_delegations(&[del1]).unwrap();
-
-        // Activated height is now set
-        let res = suite.get_activated_height();
-        assert_eq!(res.height, initial_height + 1);
 
         suite
             .commit_public_randomness(&pk_hex, &pub_rand, &pubrand_signature)

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -1,11 +1,21 @@
+use crate::msg::QueryMsg::JailedFinalityProviders;
+use crate::msg::{
+    ActiveFinalityProvidersResponse, EvidenceResponse, FinalitySignatureResponse, InstantiateMsg,
+    JailedFinalityProvider, JailedFinalityProvidersResponse,
+};
 use anyhow::Result as AnyResult;
 use babylon_apis::btc_staking_api::{ActiveBtcDelegation, FinalityProvider, NewFinalityProvider};
 use babylon_apis::error::StakingApiError;
 use babylon_apis::finality_api::{IndexedBlock, PubRandCommit};
 use babylon_apis::{btc_staking_api, finality_api, to_bech32_addr, to_canonical_addr};
 use babylon_bindings_test::BabylonApp;
+use babylon_bindings_test::{
+    BTC_FINALITY_CONTRACT_ADDR, BTC_LIGHT_CLIENT_CONTRACT_ADDR, BTC_STAKING_CONTRACT_ADDR,
+    USER_ADDR,
+};
 use btc_light_client::msg::InstantiateMsg as BtcLightClientInstantiateMsg;
 use btc_light_client::BitcoinNetwork;
+use btc_staking::msg::FinalityProviderInfo;
 use cosmwasm_std::testing::mock_dependencies;
 use cosmwasm_std::Empty;
 use cosmwasm_std::{to_json_binary, Addr, BlockInfo, Coin, Timestamp};
@@ -13,18 +23,6 @@ use cw_multi_test::{next_block, AppResponse, Contract, ContractWrapper, Executor
 use derivative::Derivative;
 use hex::ToHex;
 use std::collections::HashMap;
-
-use btc_staking::msg::{ActivatedHeightResponse, FinalityProviderInfo};
-
-use crate::msg::QueryMsg::JailedFinalityProviders;
-use crate::msg::{
-    ActiveFinalityProvidersResponse, EvidenceResponse, FinalitySignatureResponse, InstantiateMsg,
-    JailedFinalityProvider, JailedFinalityProvidersResponse,
-};
-use babylon_bindings_test::{
-    BTC_FINALITY_CONTRACT_ADDR, BTC_LIGHT_CLIENT_CONTRACT_ADDR, BTC_STAKING_CONTRACT_ADDR,
-    USER_ADDR,
-};
 
 fn contract_btc_light_client() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new(
@@ -270,17 +268,6 @@ impl Suite {
         self.app
             .wrap()
             .query_wasm_smart(self.finality.clone(), &crate::msg::QueryMsg::Config {})
-            .unwrap()
-    }
-
-    #[track_caller]
-    pub fn get_activated_height(&self) -> ActivatedHeightResponse {
-        self.app
-            .wrap()
-            .query_wasm_smart(
-                self.staking.clone(),
-                &btc_staking::msg::QueryMsg::ActivatedHeight {},
-            )
             .unwrap()
     }
 

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -42,6 +42,19 @@ pub const REWARDS: Map<&str, Uint128> = Map::new("rewards");
 /// Total pending rewards
 pub const TOTAL_PENDING_REWARDS: Item<Uint128> = Item::new("pending_rewards");
 
+/// Returns (true, height) if the BTC staking protocol is activated,
+/// Returns (false, 0) if the BTC staking protocol is not activated
+pub fn get_btc_staking_activated_height(storage: &dyn Storage) -> (bool, u64) {
+    let mut iter = FP_POWER_TABLE.range(storage, None, None, Ascending);
+    match iter.next() {
+        Some(result) => {
+            let ((height, _), _) = result.expect("shouldn't fail unless the storage is corrupted");
+            (true, height)
+        }
+        None => (false, 0),
+    }
+}
+
 pub fn get_power_table_at_height(
     storage: &dyn Storage,
     height: u64,

--- a/contracts/btc-staking/src/contract.rs
+++ b/contracts/btc-staking/src/contract.rs
@@ -81,7 +81,6 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
         QueryMsg::FinalityProvidersByTotalActiveSats { start_after, limit } => Ok(to_json_binary(
             &queries::finality_providers_by_total_active_sats(deps, start_after, limit)?,
         )?),
-        QueryMsg::ActivatedHeight {} => Ok(to_json_binary(&queries::activated_height(deps)?)?),
     }
 }
 

--- a/contracts/btc-staking/src/msg.rs
+++ b/contracts/btc-staking/src/msg.rs
@@ -74,9 +74,6 @@ pub enum QueryMsg {
         start_after: Option<FinalityProviderInfo>,
         limit: Option<u32>,
     },
-    /// Returns the height at which the contract gets its first delegation, if any.
-    #[returns(ActivatedHeightResponse)]
-    ActivatedHeight {},
 }
 
 #[cw_serde]

--- a/contracts/btc-staking/src/msg.rs
+++ b/contracts/btc-staking/src/msg.rs
@@ -106,8 +106,3 @@ pub struct FinalityProviderInfo {
     /// Whether this finality provider is slashed
     pub slashed: bool,
 }
-
-#[cw_serde]
-pub struct ActivatedHeightResponse {
-    pub height: u64,
-}

--- a/contracts/btc-staking/src/queries.rs
+++ b/contracts/btc-staking/src/queries.rs
@@ -1,11 +1,10 @@
 use crate::error::ContractError;
 use crate::msg::{
-    ActivatedHeightResponse, BtcDelegationsResponse, DelegationsByFPResponse, FinalityProviderInfo,
+    BtcDelegationsResponse, DelegationsByFPResponse, FinalityProviderInfo,
     FinalityProvidersByTotalActiveSatsResponse, FinalityProvidersResponse,
 };
 use crate::state::staking::{
-    get_fp_state_map, BtcDelegation, FinalityProviderState, ACTIVATED_HEIGHT, BTC_DELEGATIONS, FPS,
-    FP_DELEGATIONS,
+    get_fp_state_map, BtcDelegation, FinalityProviderState, BTC_DELEGATIONS, FPS, FP_DELEGATIONS,
 };
 use babylon_apis::btc_staking_api::FinalityProvider;
 use bitcoin::hashes::Hash;
@@ -175,13 +174,6 @@ pub fn finality_providers_by_total_active_sats(
         .collect::<StdResult<Vec<_>>>()?;
 
     Ok(FinalityProvidersByTotalActiveSatsResponse { fps })
-}
-
-pub fn activated_height(deps: Deps) -> Result<ActivatedHeightResponse, ContractError> {
-    let activated_height = ACTIVATED_HEIGHT.may_load(deps.storage)?.unwrap_or_default();
-    Ok(ActivatedHeightResponse {
-        height: activated_height,
-    })
 }
 
 #[cfg(test)]

--- a/contracts/btc-staking/src/staking.rs
+++ b/contracts/btc-staking/src/staking.rs
@@ -10,8 +10,7 @@ use crate::state::config::{ADMIN, CONFIG};
 use crate::state::delegations::delegations;
 use crate::state::staking::{
     get_fp_state_map, BtcDelegation, DelegatorUnbondingInfo, FinalityProviderState,
-    ACTIVATED_HEIGHT, BTC_DELEGATIONS, BTC_DELEGATION_EXPIRY_INDEX, DELEGATION_FPS, FPS,
-    FP_DELEGATIONS,
+    BTC_DELEGATIONS, BTC_DELEGATION_EXPIRY_INDEX, DELEGATION_FPS, FPS, FP_DELEGATIONS,
 };
 use crate::validation::{
     verify_active_delegation, verify_new_fp, verify_slashed_delegation, verify_undelegation,
@@ -206,11 +205,6 @@ fn handle_active_delegation(
     // Add this BTC delegation
     let delegation = BtcDelegation::from(active_delegation);
     BTC_DELEGATIONS.save(storage, staking_tx_hash.as_ref(), &delegation)?;
-
-    // Store activated height, if first delegation
-    if ACTIVATED_HEIGHT.may_load(storage)?.is_none() {
-        ACTIVATED_HEIGHT.save(storage, &(height + 1))?; // Active from the next block onwards
-    }
 
     // Index the delegation by its end height
     BTC_DELEGATION_EXPIRY_INDEX.update(

--- a/contracts/btc-staking/src/state/staking.rs
+++ b/contracts/btc-staking/src/state/staking.rs
@@ -1,11 +1,10 @@
-use cosmwasm_schema::cw_serde;
-use cw_storage_plus::{IndexedSnapshotMap, Item, Map, MultiIndex, Strategy};
-use k256::schnorr::SigningKey;
-
 use crate::error::ContractError;
 use crate::state::fp_index::FinalityProviderIndexes;
 use babylon_apis::btc_staking_api::{BTCDelegationStatus, FinalityProvider, HASH_SIZE};
 use babylon_apis::{btc_staking_api, Bytes};
+use cosmwasm_schema::cw_serde;
+use cw_storage_plus::{IndexedSnapshotMap, Map, MultiIndex, Strategy};
+use k256::schnorr::SigningKey;
 
 /// Finality providers by their BTC public key
 pub(crate) const FPS: Map<&str, FinalityProvider> = Map::new("fps");
@@ -36,9 +35,6 @@ pub const FP_STATE_KEY: &str = "fp_state";
 const FP_STATE_CHECKPOINTS: &str = "fp_state__checkpoints";
 const FP_STATE_CHANGELOG: &str = "fp_state__changelog";
 pub const FP_POWER_KEY: &str = "fp_state__power";
-
-/// The height at which the contract gets its first delegation
-pub const ACTIVATED_HEIGHT: Item<u64> = Item::new("activated_height");
 
 /// Indexed snapshot map for finality providers.
 ///


### PR DESCRIPTION
Part of #284

This PR moves the concept of activated height from BTC staking contract to BTC finality contract. This includes

- remove the activated height storage in BTC staking contract
- introduce functions for getting the activated height in BTC finality contract. It leverages the voting power table storage, i.e., finding the first height with non empty voting power table
- move the activated height query from BTC staking contract to BTC finality contract
- add unit tests