### PR TITLE
chore: add test `test_msg_commit_pub_rand_validate_basic`

### DIFF
--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -156,7 +156,7 @@ pub fn execute(
         } => handle_finality_signature(
             deps,
             env,
-            crate::finality::MsgAddFinalitySig {
+            crate::msg::MsgAddFinalitySig {
                 fp_btc_pk_hex: fp_pubkey_hex,
                 height,
                 pub_rand: pub_rand.into(),
@@ -174,7 +174,7 @@ pub fn execute(
         } => handle_public_randomness_commit(
             deps,
             &env,
-            crate::finality::MsgCommitPubRand {
+            crate::msg::MsgCommitPubRand {
                 fp_btc_pk_hex: fp_pubkey_hex,
                 start_height,
                 num_pub_rand,

--- a/contracts/btc-finality/src/error.rs
+++ b/contracts/btc-finality/src/error.rs
@@ -1,16 +1,54 @@
-use hex::FromHexError;
-use prost::DecodeError;
-use thiserror::Error;
-
+use crate::msg::COMMITMENT_LENGTH_BYTES;
+use babylon_apis::error::StakingApiError;
 use bitcoin::hashes::FromSliceError;
 use bitcoin::hex::HexToArrayError;
-
 use cosmwasm_std::StdError;
 use cw_controllers::AdminError;
 use cw_utils::PaymentError;
+use thiserror::Error;
 
-use babylon_apis::error::StakingApiError;
-use babylon_merkle::MerkleError;
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum PubRandCommitError {
+    #[error("Empty FP BTC PubKey")]
+    EmptyFpBtcPubKey,
+    #[error("Commitment must be {COMMITMENT_LENGTH_BYTES} bytes, got {0}")]
+    BadCommitmentLength(usize),
+    #[error("public rand commit start block height: {0} is equal or higher than start_height + num_pub_rand ({1})")]
+    OverflowInBlockHeight(u64, u64),
+    #[error("Empty signature")]
+    EmptySignature,
+    #[error("Ecdsa error: {0}")]
+    Ecdsa(String),
+    #[error(transparent)]
+    Hex(#[from] hex::FromHexError),
+}
+
+impl From<k256::ecdsa::Error> for PubRandCommitError {
+    fn from(e: k256::ecdsa::Error) -> Self {
+        Self::Ecdsa(e.to_string())
+    }
+}
+
+/// Finality signature error types.
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum FinalitySigError {
+    #[error("empty Finality Provider BTC PubKey")]
+    EmptyFpBtcPk,
+    #[error("invalid finality provider BTC public key length: got {actual}, want {expected}")]
+    InvalidFpBtcPkLength { actual: usize, expected: usize },
+    #[error("invalid public randomness length: got {actual}, want {expected}")]
+    InvalidPubRandLength { actual: usize, expected: usize },
+    #[error("empty inclusion proof")]
+    EmptyProof,
+    #[error("invalid finality signature length: got {actual}, want {expected}")]
+    InvalidFinalitySigLength { actual: usize, expected: usize },
+    #[error("invalid block app hash length: got {actual}, want {expected}")]
+    InvalidBlockAppHashLength { actual: usize, expected: usize },
+    #[error("duplicated finality vote")]
+    DuplicatedFinalitySig,
+    #[error(transparent)]
+    Hex(#[from] hex::FromHexError),
+}
 
 // TODO: Consider merging `crate::finality::PubRandCommitError` and `crate::finality::FinalitySigError`
 // into `ContractError`, or alternatively, split `ContractError` into them completely.
@@ -59,9 +97,9 @@ pub enum ContractError {
     #[error("Cannot unjail FP who's been jailed forever")]
     JailedForever {},
     #[error(transparent)]
-    PubRandCommit(#[from] crate::finality::PubRandCommitError),
+    PubRandCommit(#[from] PubRandCommitError),
     #[error(transparent)]
-    FinalitySig(#[from] crate::finality::FinalitySigError),
+    FinalitySig(#[from] FinalitySigError),
     #[error(transparent)]
     Admin(#[from] AdminError),
     #[error(transparent)]
@@ -75,11 +113,11 @@ pub enum ContractError {
     #[error(transparent)]
     StakingError(#[from] StakingApiError),
     #[error(transparent)]
-    MerkleError(#[from] MerkleError),
+    MerkleError(#[from] babylon_merkle::MerkleError),
     #[error(transparent)]
-    ProtoError(#[from] DecodeError),
+    ProtoError(#[from] prost::DecodeError),
     #[error(transparent)]
-    HexError(#[from] FromHexError),
+    HexError(#[from] hex::FromHexError),
     #[error("EOTS error: {0}")]
     EotsError(#[from] eots::Error),
 }

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -1,5 +1,6 @@
 use crate::contract::encode_smart_query;
 use crate::error::ContractError;
+use crate::msg::{MsgAddFinalitySig, MsgCommitPubRand, COMMITMENT_LENGTH_BYTES};
 use crate::state::config::{ADMIN, CONFIG};
 use crate::state::finality::{
     ensure_fp_has_power, get_last_signed_height, get_power_table_at_height, BLOCKS, EVIDENCES,
@@ -14,14 +15,12 @@ use crate::state::public_randomness::{
 use babylon_apis::btc_staking_api::FinalityProvider;
 use babylon_apis::finality_api::{Evidence, IndexedBlock, PubRandCommit};
 use babylon_apis::to_canonical_addr;
-use babylon_merkle::Proof;
 use btc_staking::msg::{FinalityProviderInfo, FinalityProvidersByTotalActiveSatsResponse};
 use cosmwasm_std::Order::Ascending;
 use cosmwasm_std::{
     to_json_binary, Addr, DepsMut, Env, Event, MessageInfo, QuerierWrapper, Response, StdResult,
     Storage, Uint128, WasmMsg,
 };
-use k256::schnorr::{signature::Verifier, Signature, VerifyingKey};
 use k256::sha2::{Digest, Sha256};
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -31,17 +30,6 @@ use std::collections::{HashMap, HashSet};
 // the size of the commitments index, protecting against potential memory exhaustion
 // or performance degradation caused by excessive future commitments.
 const MAX_PUB_RAND_COMMIT_OFFSET: u64 = 160_000;
-
-pub const COMMITMENT_LENGTH_BYTES: usize = 32;
-
-// BIP340 public key length
-pub const BIP340_PUB_KEY_LEN: usize = 32;
-// Schnorr public randomness length
-pub const SCHNORR_PUB_RAND_LEN: usize = 32;
-// Schnorr EOTS signature length
-pub const SCHNORR_EOTS_SIG_LEN: usize = 32;
-// Tendermint hash size (SHA256)
-pub const TMHASH_SIZE: usize = 32;
 
 const QUERY_LIMIT: Option<u32> = Some(30);
 
@@ -66,74 +54,6 @@ pub enum PubRandCommitError {
 impl From<k256::ecdsa::Error> for PubRandCommitError {
     fn from(e: k256::ecdsa::Error) -> Self {
         Self::Ecdsa(e.to_string())
-    }
-}
-
-// https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/tx.pb.go#L36
-pub struct MsgCommitPubRand {
-    pub fp_btc_pk_hex: String,
-    pub start_height: u64,
-    pub num_pub_rand: u64,
-    pub commitment: Vec<u8>,
-    pub sig: Vec<u8>,
-}
-
-impl MsgCommitPubRand {
-    // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg.go#L161
-    pub(crate) fn validate_basic(&self) -> Result<(), PubRandCommitError> {
-        if self.fp_btc_pk_hex.is_empty() {
-            return Err(PubRandCommitError::EmptyFpBtcPubKey);
-        }
-
-        // Checks if the commitment is exactly 32 bytes
-        if self.commitment.len() != COMMITMENT_LENGTH_BYTES {
-            return Err(PubRandCommitError::BadCommitmentLength(
-                self.commitment.len(),
-            ));
-        }
-
-        // To avoid public randomness reset,
-        // check for overflow when doing (StartHeight + NumPubRand)
-        if self.start_height >= (self.start_height + self.num_pub_rand) {
-            return Err(PubRandCommitError::OverflowInBlockHeight(
-                self.start_height,
-                self.start_height + self.num_pub_rand,
-            ));
-        }
-
-        if self.sig.is_empty() {
-            return Err(PubRandCommitError::EmptySignature);
-        }
-
-        Ok(())
-    }
-
-    fn verify_sig(&self, signing_context: String) -> Result<(), PubRandCommitError> {
-        let Self {
-            fp_btc_pk_hex,
-            start_height,
-            num_pub_rand,
-            commitment,
-            sig: signature,
-        } = self;
-
-        // get BTC public key for verification
-        let btc_pk_raw = hex::decode(fp_btc_pk_hex)?;
-        let btc_pk = VerifyingKey::from_bytes(&btc_pk_raw)?;
-
-        let schnorr_sig = Signature::try_from(signature.as_slice())?;
-
-        // get signed message
-        let mut msg: Vec<u8> = vec![];
-        msg.extend(signing_context.into_bytes());
-        msg.extend(start_height.to_be_bytes());
-        msg.extend(num_pub_rand.to_be_bytes());
-        msg.extend_from_slice(commitment);
-
-        // Verify the signature
-        btc_pk.verify(&msg, &schnorr_sig)?;
-
-        Ok(())
     }
 }
 
@@ -227,7 +147,7 @@ pub fn handle_public_randomness_commit(
 
 /// Returns the message for an EOTS signature
 /// The EOTS signature on a block will be (context || blockHeight || blockHash)
-fn msg_to_sign_for_vote(context: &str, block_height: u64, block_hash: &[u8]) -> Vec<u8> {
+pub(crate) fn msg_to_sign_for_vote(context: &str, block_height: u64, block_hash: &[u8]) -> Vec<u8> {
     let mut msg = Vec::new();
     msg.extend_from_slice(context.as_bytes());
     msg.extend_from_slice(&block_height.to_be_bytes());
@@ -254,103 +174,6 @@ pub enum FinalitySigError {
     DuplicatedFinalitySig,
     #[error(transparent)]
     Hex(#[from] hex::FromHexError),
-}
-
-// https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/tx.pb.go#L154
-pub struct MsgAddFinalitySig {
-    pub fp_btc_pk_hex: String,
-    pub height: u64,
-    pub pub_rand: Vec<u8>,
-    pub proof: Proof,
-    pub block_app_hash: Vec<u8>,
-    pub signature: Vec<u8>,
-}
-
-impl MsgAddFinalitySig {
-    // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg.go#L40
-    pub(crate) fn validate_basic(&self) -> Result<(), FinalitySigError> {
-        // Validate FP BTC PubKey
-        if self.fp_btc_pk_hex.is_empty() {
-            return Err(FinalitySigError::EmptyFpBtcPk);
-        }
-
-        // Validate FP BTC PubKey length
-        let fp_btc_pk = hex::decode(&self.fp_btc_pk_hex)?;
-        if fp_btc_pk.len() != BIP340_PUB_KEY_LEN {
-            return Err(FinalitySigError::InvalidFpBtcPkLength {
-                actual: fp_btc_pk.len(),
-                expected: BIP340_PUB_KEY_LEN,
-            });
-        }
-
-        // Validate Public Randomness length
-        if self.pub_rand.len() != SCHNORR_PUB_RAND_LEN {
-            return Err(FinalitySigError::InvalidPubRandLength {
-                actual: self.pub_rand.len(),
-                expected: SCHNORR_PUB_RAND_LEN,
-            });
-        }
-
-        // `self.proof` is not an Option, thus it must not be empty.
-
-        // Validate finality signature length
-        if self.signature.len() != SCHNORR_EOTS_SIG_LEN {
-            return Err(FinalitySigError::InvalidFinalitySigLength {
-                actual: self.signature.len(),
-                expected: SCHNORR_EOTS_SIG_LEN,
-            });
-        }
-
-        // Validate block app hash length
-        if self.block_app_hash.len() != TMHASH_SIZE {
-            return Err(FinalitySigError::InvalidBlockAppHashLength {
-                actual: self.block_app_hash.len(),
-                expected: TMHASH_SIZE,
-            });
-        }
-
-        Ok(())
-    }
-
-    /// Verifies the finality signature message w.r.t. the public randomness commitment:
-    /// - Public randomness inclusion proof.
-    fn verify_finality_signature(
-        &self,
-        pr_commit: &PubRandCommit,
-        signing_context: &str,
-    ) -> Result<(), ContractError> {
-        let proof_height = pr_commit.start_height + self.proof.index;
-        if self.height != proof_height {
-            return Err(ContractError::InvalidFinalitySigHeight(
-                proof_height,
-                self.height,
-            ));
-        }
-        // Verify the total amount of randomness is the same as in the commitment
-        if self.proof.total != pr_commit.num_pub_rand {
-            return Err(ContractError::InvalidFinalitySigAmount(
-                self.proof.total,
-                pr_commit.num_pub_rand,
-            ));
-        }
-        // Verify the proof of inclusion for this public randomness
-        self.proof.validate_basic()?;
-        self.proof.verify(&pr_commit.commitment, &self.pub_rand)?;
-
-        // Public randomness is good, verify finality signature
-        let pubkey = eots::PublicKey::from_hex(&self.fp_btc_pk_hex)?;
-
-        // The EOTS signature on a block will be (signing_context || block_height || block_app_hash)
-        let msg = msg_to_sign_for_vote(signing_context, self.height, &self.block_app_hash);
-
-        let msg_hash = Sha256::digest(msg);
-
-        if !pubkey.verify_hash(&self.pub_rand, msg_hash.into(), &self.signature)? {
-            return Err(ContractError::FailedToVerifyEots);
-        }
-
-        Ok(())
-    }
 }
 
 pub fn handle_finality_signature(

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -951,6 +951,105 @@ mod tests {
         (0..len).map(|_| rng.gen()).collect()
     }
 
+    // Helper function to generate random BTC key pair
+    fn gen_random_btc_key_pair(rng: &mut StdRng) -> (Vec<u8>, Vec<u8>) {
+        let sk = gen_random_bytes(rng, 32);
+        let pk = gen_random_bytes(rng, 32);
+        (sk, pk)
+    }
+
+    struct MsgCommitPubRandTestCase {
+        name: &'static str,
+        msg_modifier: fn(&mut MsgCommitPubRand),
+        expected: Result<(), PubRandCommitError>,
+    }
+
+    // Helper function to generate random message
+    fn gen_random_msg_commit_pub_rand(
+        rng: &mut StdRng,
+        start_height: u64,
+        num_pub_rand: u64,
+    ) -> MsgCommitPubRand {
+        let (_, pk) = gen_random_btc_key_pair(rng);
+        let commitment = gen_random_bytes(rng, COMMITMENT_LENGTH_BYTES);
+        let sig = gen_random_bytes(rng, 64); // BIP340 signature length
+
+        MsgCommitPubRand {
+            fp_btc_pk_hex: hex::encode(&pk),
+            start_height,
+            num_pub_rand,
+            commitment,
+            sig,
+        }
+    }
+
+    // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg_test.go#L85
+    #[test]
+    fn test_msg_commit_pub_rand_validate_basic() {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        let test_cases = vec![
+            MsgCommitPubRandTestCase {
+                name: "valid message",
+                msg_modifier: |_msg| {
+                    // No modification needed for valid message
+                },
+                expected: Ok(()),
+            },
+            MsgCommitPubRandTestCase {
+                name: "invalid commitment size",
+                msg_modifier: |msg: &mut MsgCommitPubRand| {
+                    msg.commitment = b"too-short".to_vec();
+                },
+                expected: Err(PubRandCommitError::BadCommitmentLength(9)),
+            },
+            MsgCommitPubRandTestCase {
+                name: "empty FP BTC PubKey",
+                msg_modifier: |msg: &mut MsgCommitPubRand| {
+                    msg.fp_btc_pk_hex = Default::default();
+                },
+                expected: Err(PubRandCommitError::EmptyFpBtcPubKey),
+            },
+            MsgCommitPubRandTestCase {
+                name: "empty signature",
+                msg_modifier: |msg| {
+                    msg.sig = vec![];
+                },
+                expected: Err(PubRandCommitError::EmptySignature),
+            },
+        ];
+
+        for MsgCommitPubRandTestCase {
+            name,
+            msg_modifier,
+            expected,
+        } in test_cases
+        {
+            let start_height = rng.gen_range(1..10);
+            let num_pub_rand = rng.gen_range(1..100);
+            let mut msg = gen_random_msg_commit_pub_rand(&mut rng, start_height, num_pub_rand);
+
+            // Apply the test case modifier
+            msg_modifier(&mut msg);
+
+            // Validate the message
+            assert_eq!(msg.validate_basic(), expected, "Test case failed: {name}");
+        }
+
+        // overflow in block height
+        let start_height = rng.gen_range(1..10);
+        let num_pub_rand = rng.gen_range(1..100);
+        let mut msg = gen_random_msg_commit_pub_rand(&mut rng, start_height, num_pub_rand);
+        msg.num_pub_rand = 0;
+        assert_eq!(
+            msg.validate_basic(),
+            Err(PubRandCommitError::OverflowInBlockHeight(
+                start_height,
+                start_height
+            ))
+        );
+    }
+
     // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg_test.go#L167
     #[test]
     fn test_msg_add_finality_sig_validate_basic() {

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -958,11 +958,14 @@ mod tests {
         (sk, pk)
     }
 
-    struct MsgCommitPubRandTestCase {
+    struct MsgTestCase<Msg, MsgErr> {
         name: &'static str,
-        msg_modifier: fn(&mut MsgCommitPubRand),
-        expected: Result<(), PubRandCommitError>,
+        msg_modifier: fn(&mut Msg),
+        expected: Result<(), MsgErr>,
     }
+
+    type MsgCommitPubRandTestCase = MsgTestCase<MsgCommitPubRand, PubRandCommitError>;
+    type MsgAddFinalitySigTestCase = MsgTestCase<MsgAddFinalitySig, FinalitySigError>;
 
     // Helper function to generate random message
     fn gen_random_msg_commit_pub_rand(
@@ -1055,25 +1058,19 @@ mod tests {
     fn test_msg_add_finality_sig_validate_basic() {
         let mut rng = StdRng::seed_from_u64(1);
 
-        struct TestCase {
-            name: &'static str,
-            msg_modifier: fn(&mut MsgAddFinalitySig),
-            expected: Result<(), FinalitySigError>,
-        }
-
         let test_cases = vec![
-            TestCase {
+            MsgAddFinalitySigTestCase {
                 name: "valid message",
                 // No modification needed for valid message
                 msg_modifier: |_| {},
                 expected: Ok(()),
             },
-            TestCase {
+            MsgAddFinalitySigTestCase {
                 name: "empty FP BTC PubKey",
                 msg_modifier: |msg| msg.fp_btc_pk_hex.clear(),
                 expected: Err(FinalitySigError::EmptyFpBtcPk),
             },
-            TestCase {
+            MsgAddFinalitySigTestCase {
                 name: "invalid FP BTC PubKey length",
                 msg_modifier: |msg| {
                     msg.fp_btc_pk_hex = hex::encode(vec![0u8; 16]); // Too short
@@ -1083,7 +1080,7 @@ mod tests {
                     expected: 32,
                 }),
             },
-            TestCase {
+            MsgAddFinalitySigTestCase {
                 name: "empty Public Randomness",
                 msg_modifier: |msg| msg.pub_rand.clear(),
                 expected: Err(FinalitySigError::InvalidPubRandLength {
@@ -1091,7 +1088,7 @@ mod tests {
                     expected: 32,
                 }),
             },
-            TestCase {
+            MsgAddFinalitySigTestCase {
                 name: "invalid Public Randomness length",
                 msg_modifier: |msg| {
                     msg.pub_rand = vec![0u8; 16]; // Too short
@@ -1101,7 +1098,7 @@ mod tests {
                     expected: 32,
                 }),
             },
-            TestCase {
+            MsgAddFinalitySigTestCase {
                 name: "empty finality signature",
                 msg_modifier: |msg| msg.signature.clear(),
                 expected: Err(FinalitySigError::InvalidFinalitySigLength {
@@ -1109,7 +1106,7 @@ mod tests {
                     expected: 32,
                 }),
             },
-            TestCase {
+            MsgAddFinalitySigTestCase {
                 name: "invalid finality signature length",
                 msg_modifier: |msg| {
                     msg.signature = vec![0u8; 16]; // Too short
@@ -1119,7 +1116,7 @@ mod tests {
                     expected: 32,
                 }),
             },
-            TestCase {
+            MsgAddFinalitySigTestCase {
                 name: "invalid block app hash length",
                 msg_modifier: |msg| {
                     msg.block_app_hash = vec![0u8; 16]; // Too short
@@ -1131,7 +1128,7 @@ mod tests {
             },
         ];
 
-        for TestCase {
+        for MsgAddFinalitySigTestCase {
             name,
             msg_modifier,
             expected,

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -32,16 +32,16 @@ use std::collections::{HashMap, HashSet};
 // or performance degradation caused by excessive future commitments.
 const MAX_PUB_RAND_COMMIT_OFFSET: u64 = 160_000;
 
-const COMMITMENT_LENGTH_BYTES: usize = 32;
+pub const COMMITMENT_LENGTH_BYTES: usize = 32;
 
 // BIP340 public key length
-const BIP340_PUB_KEY_LEN: usize = 32;
+pub const BIP340_PUB_KEY_LEN: usize = 32;
 // Schnorr public randomness length
-const SCHNORR_PUB_RAND_LEN: usize = 32;
+pub const SCHNORR_PUB_RAND_LEN: usize = 32;
 // Schnorr EOTS signature length
-const SCHNORR_EOTS_SIG_LEN: usize = 32;
+pub const SCHNORR_EOTS_SIG_LEN: usize = 32;
 // Tendermint hash size (SHA256)
-const TMHASH_SIZE: usize = 32;
+pub const TMHASH_SIZE: usize = 32;
 
 const QUERY_LIMIT: Option<u32> = Some(30);
 
@@ -80,7 +80,7 @@ pub struct MsgCommitPubRand {
 
 impl MsgCommitPubRand {
     // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg.go#L161
-    fn validate_basic(&self) -> Result<(), PubRandCommitError> {
+    pub(crate) fn validate_basic(&self) -> Result<(), PubRandCommitError> {
         if self.fp_btc_pk_hex.is_empty() {
             return Err(PubRandCommitError::EmptyFpBtcPubKey);
         }
@@ -268,7 +268,7 @@ pub struct MsgAddFinalitySig {
 
 impl MsgAddFinalitySig {
     // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg.go#L40
-    fn validate_basic(&self) -> Result<(), FinalitySigError> {
+    pub(crate) fn validate_basic(&self) -> Result<(), FinalitySigError> {
         // Validate FP BTC PubKey
         if self.fp_btc_pk_hex.is_empty() {
             return Err(FinalitySigError::EmptyFpBtcPk);
@@ -938,221 +938,4 @@ pub fn distribute_rewards_fps(deps: &mut DepsMut, env: &Env) -> Result<(), Contr
         Ok::<Uint128, ContractError>(r + accumulated_rewards)
     })?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
-
-    // Helper function to generate random bytes
-    fn gen_random_bytes(rng: &mut StdRng, len: usize) -> Vec<u8> {
-        (0..len).map(|_| rng.gen()).collect()
-    }
-
-    // Helper function to generate random BTC key pair
-    fn gen_random_btc_key_pair(rng: &mut StdRng) -> (Vec<u8>, Vec<u8>) {
-        let sk = gen_random_bytes(rng, 32);
-        let pk = gen_random_bytes(rng, 32);
-        (sk, pk)
-    }
-
-    struct MsgTestCase<Msg, MsgErr> {
-        name: &'static str,
-        msg_modifier: fn(&mut Msg),
-        expected: Result<(), MsgErr>,
-    }
-
-    type MsgCommitPubRandTestCase = MsgTestCase<MsgCommitPubRand, PubRandCommitError>;
-    type MsgAddFinalitySigTestCase = MsgTestCase<MsgAddFinalitySig, FinalitySigError>;
-
-    // Helper function to generate random message
-    fn gen_random_msg_commit_pub_rand(
-        rng: &mut StdRng,
-        start_height: u64,
-        num_pub_rand: u64,
-    ) -> MsgCommitPubRand {
-        let (_, pk) = gen_random_btc_key_pair(rng);
-        let commitment = gen_random_bytes(rng, COMMITMENT_LENGTH_BYTES);
-        let sig = gen_random_bytes(rng, 64); // BIP340 signature length
-
-        MsgCommitPubRand {
-            fp_btc_pk_hex: hex::encode(&pk),
-            start_height,
-            num_pub_rand,
-            commitment,
-            sig,
-        }
-    }
-
-    // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg_test.go#L85
-    #[test]
-    fn test_msg_commit_pub_rand_validate_basic() {
-        let mut rng = StdRng::seed_from_u64(1);
-
-        let test_cases = vec![
-            MsgCommitPubRandTestCase {
-                name: "valid message",
-                msg_modifier: |_msg| {
-                    // No modification needed for valid message
-                },
-                expected: Ok(()),
-            },
-            MsgCommitPubRandTestCase {
-                name: "invalid commitment size",
-                msg_modifier: |msg: &mut MsgCommitPubRand| {
-                    msg.commitment = b"too-short".to_vec();
-                },
-                expected: Err(PubRandCommitError::BadCommitmentLength(9)),
-            },
-            MsgCommitPubRandTestCase {
-                name: "empty FP BTC PubKey",
-                msg_modifier: |msg: &mut MsgCommitPubRand| {
-                    msg.fp_btc_pk_hex = Default::default();
-                },
-                expected: Err(PubRandCommitError::EmptyFpBtcPubKey),
-            },
-            MsgCommitPubRandTestCase {
-                name: "empty signature",
-                msg_modifier: |msg| {
-                    msg.sig = vec![];
-                },
-                expected: Err(PubRandCommitError::EmptySignature),
-            },
-        ];
-
-        for MsgCommitPubRandTestCase {
-            name,
-            msg_modifier,
-            expected,
-        } in test_cases
-        {
-            let start_height = rng.gen_range(1..10);
-            let num_pub_rand = rng.gen_range(1..100);
-            let mut msg = gen_random_msg_commit_pub_rand(&mut rng, start_height, num_pub_rand);
-
-            // Apply the test case modifier
-            msg_modifier(&mut msg);
-
-            // Validate the message
-            assert_eq!(msg.validate_basic(), expected, "Test case failed: {name}");
-        }
-
-        // overflow in block height
-        let start_height = rng.gen_range(1..10);
-        let num_pub_rand = rng.gen_range(1..100);
-        let mut msg = gen_random_msg_commit_pub_rand(&mut rng, start_height, num_pub_rand);
-        msg.num_pub_rand = 0;
-        assert_eq!(
-            msg.validate_basic(),
-            Err(PubRandCommitError::OverflowInBlockHeight(
-                start_height,
-                start_height
-            ))
-        );
-    }
-
-    // https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg_test.go#L167
-    #[test]
-    fn test_msg_add_finality_sig_validate_basic() {
-        let mut rng = StdRng::seed_from_u64(1);
-
-        let test_cases = vec![
-            MsgAddFinalitySigTestCase {
-                name: "valid message",
-                // No modification needed for valid message
-                msg_modifier: |_| {},
-                expected: Ok(()),
-            },
-            MsgAddFinalitySigTestCase {
-                name: "empty FP BTC PubKey",
-                msg_modifier: |msg| msg.fp_btc_pk_hex.clear(),
-                expected: Err(FinalitySigError::EmptyFpBtcPk),
-            },
-            MsgAddFinalitySigTestCase {
-                name: "invalid FP BTC PubKey length",
-                msg_modifier: |msg| {
-                    msg.fp_btc_pk_hex = hex::encode(vec![0u8; 16]); // Too short
-                },
-                expected: Err(FinalitySigError::InvalidFpBtcPkLength {
-                    actual: 16,
-                    expected: 32,
-                }),
-            },
-            MsgAddFinalitySigTestCase {
-                name: "empty Public Randomness",
-                msg_modifier: |msg| msg.pub_rand.clear(),
-                expected: Err(FinalitySigError::InvalidPubRandLength {
-                    actual: 0,
-                    expected: 32,
-                }),
-            },
-            MsgAddFinalitySigTestCase {
-                name: "invalid Public Randomness length",
-                msg_modifier: |msg| {
-                    msg.pub_rand = vec![0u8; 16]; // Too short
-                },
-                expected: Err(FinalitySigError::InvalidPubRandLength {
-                    actual: 16,
-                    expected: 32,
-                }),
-            },
-            MsgAddFinalitySigTestCase {
-                name: "empty finality signature",
-                msg_modifier: |msg| msg.signature.clear(),
-                expected: Err(FinalitySigError::InvalidFinalitySigLength {
-                    actual: 0,
-                    expected: 32,
-                }),
-            },
-            MsgAddFinalitySigTestCase {
-                name: "invalid finality signature length",
-                msg_modifier: |msg| {
-                    msg.signature = vec![0u8; 16]; // Too short
-                },
-                expected: Err(FinalitySigError::InvalidFinalitySigLength {
-                    actual: 16,
-                    expected: 32,
-                }),
-            },
-            MsgAddFinalitySigTestCase {
-                name: "invalid block app hash length",
-                msg_modifier: |msg| {
-                    msg.block_app_hash = vec![0u8; 16]; // Too short
-                },
-                expected: Err(FinalitySigError::InvalidBlockAppHashLength {
-                    actual: 16,
-                    expected: 32,
-                }),
-            },
-        ];
-
-        for MsgAddFinalitySigTestCase {
-            name,
-            msg_modifier,
-            expected,
-        } in test_cases
-        {
-            // Create a valid message
-            let mut msg = MsgAddFinalitySig {
-                fp_btc_pk_hex: hex::encode(gen_random_bytes(&mut rng, BIP340_PUB_KEY_LEN)),
-                height: rng.gen_range(1..1000),
-                pub_rand: gen_random_bytes(&mut rng, SCHNORR_PUB_RAND_LEN),
-                proof: Proof {
-                    total: 0,
-                    index: 0,
-                    leaf_hash: Default::default(),
-                    aunts: Default::default(),
-                },
-                block_app_hash: gen_random_bytes(&mut rng, TMHASH_SIZE),
-                signature: gen_random_bytes(&mut rng, SCHNORR_EOTS_SIG_LEN),
-            };
-
-            // Apply the test case modifier
-            msg_modifier(&mut msg);
-
-            assert_eq!(msg.validate_basic(), expected, "Test case failed: {}", name);
-        }
-    }
 }

--- a/contracts/btc-finality/src/lib.rs
+++ b/contracts/btc-finality/src/lib.rs
@@ -8,3 +8,5 @@ pub mod state;
 
 #[cfg(test)]
 mod multitest;
+#[cfg(test)]
+mod tests;

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -1,5 +1,4 @@
-use crate::error::ContractError;
-use crate::finality::{FinalitySigError, PubRandCommitError};
+use crate::error::{ContractError, FinalitySigError, PubRandCommitError};
 use babylon_apis::finality_api::{Evidence, IndexedBlock};
 use babylon_merkle::Proof;
 use cosmwasm_schema::{cw_serde, QueryResponses};

--- a/contracts/btc-finality/src/tests.rs
+++ b/contracts/btc-finality/src/tests.rs
@@ -1,6 +1,7 @@
-use crate::finality::{
-    FinalitySigError, MsgAddFinalitySig, MsgCommitPubRand, PubRandCommitError, BIP340_PUB_KEY_LEN,
-    COMMITMENT_LENGTH_BYTES, SCHNORR_EOTS_SIG_LEN, SCHNORR_PUB_RAND_LEN, TMHASH_SIZE,
+use crate::finality::{FinalitySigError, PubRandCommitError};
+use crate::msg::{
+    MsgAddFinalitySig, MsgCommitPubRand, BIP340_PUB_KEY_LEN, COMMITMENT_LENGTH_BYTES,
+    SCHNORR_EOTS_SIG_LEN, SCHNORR_PUB_RAND_LEN, TMHASH_SIZE,
 };
 use babylon_merkle::Proof;
 use rand::rngs::StdRng;

--- a/contracts/btc-finality/src/tests.rs
+++ b/contracts/btc-finality/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::finality::{FinalitySigError, PubRandCommitError};
+use crate::error::{FinalitySigError, PubRandCommitError};
 use crate::msg::{
     MsgAddFinalitySig, MsgCommitPubRand, BIP340_PUB_KEY_LEN, COMMITMENT_LENGTH_BYTES,
     SCHNORR_EOTS_SIG_LEN, SCHNORR_PUB_RAND_LEN, TMHASH_SIZE,

--- a/contracts/btc-finality/src/tests.rs
+++ b/contracts/btc-finality/src/tests.rs
@@ -1,0 +1,217 @@
+use crate::finality::{
+    FinalitySigError, MsgAddFinalitySig, MsgCommitPubRand, PubRandCommitError, BIP340_PUB_KEY_LEN,
+    COMMITMENT_LENGTH_BYTES, SCHNORR_EOTS_SIG_LEN, SCHNORR_PUB_RAND_LEN, TMHASH_SIZE,
+};
+use babylon_merkle::Proof;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+// Helper function to generate random bytes
+fn gen_random_bytes(rng: &mut StdRng, len: usize) -> Vec<u8> {
+    (0..len).map(|_| rng.gen()).collect()
+}
+
+// Helper function to generate random BTC key pair
+fn gen_random_btc_key_pair(rng: &mut StdRng) -> (Vec<u8>, Vec<u8>) {
+    let sk = gen_random_bytes(rng, 32);
+    let pk = gen_random_bytes(rng, 32);
+    (sk, pk)
+}
+
+struct MsgTestCase<Msg, MsgErr> {
+    name: &'static str,
+    msg_modifier: fn(&mut Msg),
+    expected: Result<(), MsgErr>,
+}
+
+type MsgCommitPubRandTestCase = MsgTestCase<MsgCommitPubRand, PubRandCommitError>;
+type MsgAddFinalitySigTestCase = MsgTestCase<MsgAddFinalitySig, FinalitySigError>;
+
+// Helper function to generate random message
+fn gen_random_msg_commit_pub_rand(
+    rng: &mut StdRng,
+    start_height: u64,
+    num_pub_rand: u64,
+) -> MsgCommitPubRand {
+    let (_, pk) = gen_random_btc_key_pair(rng);
+    let commitment = gen_random_bytes(rng, COMMITMENT_LENGTH_BYTES);
+    let sig = gen_random_bytes(rng, 64); // BIP340 signature length
+
+    MsgCommitPubRand {
+        fp_btc_pk_hex: hex::encode(&pk),
+        start_height,
+        num_pub_rand,
+        commitment,
+        sig,
+    }
+}
+
+// https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg_test.go#L85
+#[test]
+fn test_msg_commit_pub_rand_validate_basic() {
+    let mut rng = StdRng::seed_from_u64(1);
+
+    let test_cases = vec![
+        MsgCommitPubRandTestCase {
+            name: "valid message",
+            msg_modifier: |_msg| {
+                // No modification needed for valid message
+            },
+            expected: Ok(()),
+        },
+        MsgCommitPubRandTestCase {
+            name: "invalid commitment size",
+            msg_modifier: |msg: &mut MsgCommitPubRand| {
+                msg.commitment = b"too-short".to_vec();
+            },
+            expected: Err(PubRandCommitError::BadCommitmentLength(9)),
+        },
+        MsgCommitPubRandTestCase {
+            name: "empty FP BTC PubKey",
+            msg_modifier: |msg: &mut MsgCommitPubRand| {
+                msg.fp_btc_pk_hex = Default::default();
+            },
+            expected: Err(PubRandCommitError::EmptyFpBtcPubKey),
+        },
+        MsgCommitPubRandTestCase {
+            name: "empty signature",
+            msg_modifier: |msg| {
+                msg.sig = vec![];
+            },
+            expected: Err(PubRandCommitError::EmptySignature),
+        },
+    ];
+
+    for MsgCommitPubRandTestCase {
+        name,
+        msg_modifier,
+        expected,
+    } in test_cases
+    {
+        let start_height = rng.gen_range(1..10);
+        let num_pub_rand = rng.gen_range(1..100);
+        let mut msg = gen_random_msg_commit_pub_rand(&mut rng, start_height, num_pub_rand);
+
+        // Apply the test case modifier
+        msg_modifier(&mut msg);
+
+        // Validate the message
+        assert_eq!(msg.validate_basic(), expected, "Test case failed: {name}");
+    }
+
+    // overflow in block height
+    let start_height = rng.gen_range(1..10);
+    let num_pub_rand = rng.gen_range(1..100);
+    let mut msg = gen_random_msg_commit_pub_rand(&mut rng, start_height, num_pub_rand);
+    msg.num_pub_rand = 0;
+    assert_eq!(
+        msg.validate_basic(),
+        Err(PubRandCommitError::OverflowInBlockHeight(
+            start_height,
+            start_height
+        ))
+    );
+}
+
+// https://github.com/babylonlabs-io/babylon/blob/49972e2d3e35caf0a685c37e1f745c47b75bfc69/x/finality/types/msg_test.go#L167
+#[test]
+fn test_msg_add_finality_sig_validate_basic() {
+    let mut rng = StdRng::seed_from_u64(1);
+
+    let test_cases = vec![
+        MsgAddFinalitySigTestCase {
+            name: "valid message",
+            // No modification needed for valid message
+            msg_modifier: |_| {},
+            expected: Ok(()),
+        },
+        MsgAddFinalitySigTestCase {
+            name: "empty FP BTC PubKey",
+            msg_modifier: |msg| msg.fp_btc_pk_hex.clear(),
+            expected: Err(FinalitySigError::EmptyFpBtcPk),
+        },
+        MsgAddFinalitySigTestCase {
+            name: "invalid FP BTC PubKey length",
+            msg_modifier: |msg| {
+                msg.fp_btc_pk_hex = hex::encode(vec![0u8; 16]); // Too short
+            },
+            expected: Err(FinalitySigError::InvalidFpBtcPkLength {
+                actual: 16,
+                expected: 32,
+            }),
+        },
+        MsgAddFinalitySigTestCase {
+            name: "empty Public Randomness",
+            msg_modifier: |msg| msg.pub_rand.clear(),
+            expected: Err(FinalitySigError::InvalidPubRandLength {
+                actual: 0,
+                expected: 32,
+            }),
+        },
+        MsgAddFinalitySigTestCase {
+            name: "invalid Public Randomness length",
+            msg_modifier: |msg| {
+                msg.pub_rand = vec![0u8; 16]; // Too short
+            },
+            expected: Err(FinalitySigError::InvalidPubRandLength {
+                actual: 16,
+                expected: 32,
+            }),
+        },
+        MsgAddFinalitySigTestCase {
+            name: "empty finality signature",
+            msg_modifier: |msg| msg.signature.clear(),
+            expected: Err(FinalitySigError::InvalidFinalitySigLength {
+                actual: 0,
+                expected: 32,
+            }),
+        },
+        MsgAddFinalitySigTestCase {
+            name: "invalid finality signature length",
+            msg_modifier: |msg| {
+                msg.signature = vec![0u8; 16]; // Too short
+            },
+            expected: Err(FinalitySigError::InvalidFinalitySigLength {
+                actual: 16,
+                expected: 32,
+            }),
+        },
+        MsgAddFinalitySigTestCase {
+            name: "invalid block app hash length",
+            msg_modifier: |msg| {
+                msg.block_app_hash = vec![0u8; 16]; // Too short
+            },
+            expected: Err(FinalitySigError::InvalidBlockAppHashLength {
+                actual: 16,
+                expected: 32,
+            }),
+        },
+    ];
+
+    for MsgAddFinalitySigTestCase {
+        name,
+        msg_modifier,
+        expected,
+    } in test_cases
+    {
+        // Create a valid message
+        let mut msg = MsgAddFinalitySig {
+            fp_btc_pk_hex: hex::encode(gen_random_bytes(&mut rng, BIP340_PUB_KEY_LEN)),
+            height: rng.gen_range(1..1000),
+            pub_rand: gen_random_bytes(&mut rng, SCHNORR_PUB_RAND_LEN),
+            proof: Proof {
+                total: 0,
+                index: 0,
+                leaf_hash: Default::default(),
+                aunts: Default::default(),
+            },
+            block_app_hash: gen_random_bytes(&mut rng, TMHASH_SIZE),
+            signature: gen_random_bytes(&mut rng, SCHNORR_EOTS_SIG_LEN),
+        };
+
+        // Apply the test case modifier
+        msg_modifier(&mut msg);
+
+        assert_eq!(msg.validate_basic(), expected, "Test case failed: {name}");
+    }
+}


### PR DESCRIPTION
This PR primarily adds the test `test_msg_commit_pub_rand_validate_basic` with some pure refactorings:

   * `MsgCommitPubRand` and `MsgAddFinalitySig` have been moved from `finality.rs` to `msg.rs`.
   *  The `PubRandCommitError` and `FinalitySigError` enums have been moved from `finality.rs` to `error.rs`
   
   Part of #271