### PR TITLE
chore: have default values for instantiation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#299](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/299) chore: have default values for instantiation messages
 - [#297](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/297) btc-staking: refactor queries
 - [#294](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/294) slashing: align the slashing implementation with Babylon
 - [#293](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/293) ibc: clean up IBC handshake process

--- a/contracts/babylon/src/contract.rs
+++ b/contracts/babylon/src/contract.rs
@@ -529,12 +529,22 @@ mod tests {
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(1, res.messages.len());
         assert_eq!(REPLY_ID_INSTANTIATE_FINALITY, res.messages[0].id);
+        // Create the expected finality message with default values
+        let expected_finality_msg = finality_api::InstantiateMsg {
+            admin: None,
+            max_active_finality_providers: None,
+            min_pub_rand: None,
+            reward_interval: None,
+            missed_blocks_window: None,
+            jail_duration: None,
+        };
+
         assert_eq!(
             res.messages[0].msg,
             WasmMsg::Instantiate {
                 admin: None,
                 code_id: 2,
-                msg: Binary::from(b"{}"),
+                msg: to_json_binary(&expected_finality_msg).unwrap(),
                 funds: vec![],
                 label: "BTC Finality".into(),
             }

--- a/contracts/babylon/src/contract.rs
+++ b/contracts/babylon/src/contract.rs
@@ -54,7 +54,7 @@ pub fn instantiate(
     // instantiate btc light client contract first
     // It has to be before btc staking and finality contracts which depend on it
     if let Some(btc_light_client_code_id) = msg.btc_light_client_code_id {
-        let init_btclc_msg = if let Some(btc_light_client_msg) = msg.btc_light_client_msg {
+        let init_btc_lc_msg = if let Some(btc_light_client_msg) = msg.btc_light_client_msg {
             // If the message is provided, use it
             btc_light_client_msg
         } else {
@@ -69,7 +69,7 @@ pub fn instantiate(
         let init_msg = WasmMsg::Instantiate {
             admin: msg.admin.clone(),
             code_id: btc_light_client_code_id,
-            msg: init_btclc_msg,
+            msg: init_btc_lc_msg,
             funds: vec![],
             label: "BTC Light Client".into(),
         };
@@ -78,7 +78,7 @@ pub fn instantiate(
     }
 
     if let Some(btc_staking_code_id) = msg.btc_staking_code_id {
-        let init_btcst_msg = if let Some(btc_staking_msg) = msg.btc_staking_msg {
+        let init_btc_staking_msg = if let Some(btc_staking_msg) = msg.btc_staking_msg {
             // If the message is provided, use it
             btc_staking_msg
         } else {
@@ -91,7 +91,7 @@ pub fn instantiate(
         let init_msg = WasmMsg::Instantiate {
             admin: msg.admin.clone(),
             code_id: btc_staking_code_id,
-            msg: init_btcst_msg,
+            msg: init_btc_staking_msg,
             funds: vec![],
             label: "BTC Staking".into(),
         };
@@ -106,7 +106,7 @@ pub fn instantiate(
     }
 
     if let Some(btc_finality_code_id) = msg.btc_finality_code_id {
-        let init_btcf_msg = if let Some(btc_finality_msg) = msg.btc_finality_msg {
+        let init_btc_finality_msg = if let Some(btc_finality_msg) = msg.btc_finality_msg {
             // If the message is provided, use it
             btc_finality_msg
         } else {
@@ -114,18 +114,14 @@ pub fn instantiate(
             // and default values for the finality contract
             to_json_binary(&finality_api::InstantiateMsg {
                 admin: msg.admin.clone(),
-                max_active_finality_providers: None,
-                min_pub_rand: None,
-                reward_interval: None,
-                missed_blocks_window: None,
-                jail_duration: None,
+                ..Default::default()
             })?
         };
         // Instantiate BTC finality contract
         let init_msg = WasmMsg::Instantiate {
             admin: msg.admin,
             code_id: btc_finality_code_id,
-            msg: init_btcf_msg,
+            msg: init_btc_finality_msg,
             funds: vec![],
             label: "BTC Finality".into(),
         };
@@ -530,14 +526,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
         assert_eq!(REPLY_ID_INSTANTIATE_FINALITY, res.messages[0].id);
         // Create the expected finality message with default values
-        let expected_finality_msg = finality_api::InstantiateMsg {
-            admin: None,
-            max_active_finality_providers: None,
-            min_pub_rand: None,
-            reward_interval: None,
-            missed_blocks_window: None,
-            jail_duration: None,
-        };
+        let expected_finality_msg = finality_api::InstantiateMsg::default();
 
         assert_eq!(
             res.messages[0].msg,

--- a/contracts/babylon/src/multitest/suite.rs
+++ b/contracts/babylon/src/multitest/suite.rs
@@ -127,18 +127,18 @@ impl SuiteBuilder {
 
         let checkpoint_finalization_timeout = self.checkpoint_finalization_timeout.unwrap_or(1);
 
-        let light_client_msg = match &self.light_client_msg {
-            Some(msg) => Some(Binary::from(msg.as_bytes())),
-            None => None,
-        };
-        let staking_msg = match &self.staking_msg {
-            Some(msg) => Some(Binary::from(msg.as_bytes())),
-            None => None,
-        };
-        let finality_msg = match &self.finality_msg {
-            Some(msg) => Some(Binary::from(msg.as_bytes())),
-            None => None,
-        };
+        let light_client_msg = self
+            .light_client_msg
+            .as_ref()
+            .map(|msg| Binary::from(msg.as_bytes()));
+        let staking_msg = self
+            .staking_msg
+            .as_ref()
+            .map(|msg| Binary::from(msg.as_bytes()));
+        let finality_msg = self
+            .finality_msg
+            .as_ref()
+            .map(|msg| Binary::from(msg.as_bytes()));
         let contract = app
             .instantiate_contract(
                 contract_code_id,

--- a/contracts/babylon/src/multitest/suite.rs
+++ b/contracts/babylon/src/multitest/suite.rs
@@ -124,21 +124,17 @@ impl SuiteBuilder {
         let checkpoint_finalization_timeout = self.checkpoint_finalization_timeout.unwrap_or(1);
 
         let light_client_msg = match &self.light_client_msg {
-            Some(msg) => Binary::from(msg.as_bytes()),
-            None => {
-                let btc_lc_init_msg = BtcLightClientInstantiateMsg {
-                    network: BitcoinNetwork::Testnet,
-                    btc_confirmation_depth: 1,
-                    checkpoint_finalization_timeout,
-                    admin: None,
-                };
-
-                to_json_binary(&btc_lc_init_msg).unwrap()
-            }
+            Some(msg) => Some(Binary::from(msg.as_bytes())),
+            None => None,
         };
-
-        let staking_msg = self.staking_msg.map(|msg| Binary::from(msg.as_bytes()));
-        let finality_msg = self.finality_msg.map(|msg| Binary::from(msg.as_bytes()));
+        let staking_msg = match &self.staking_msg {
+            Some(msg) => Some(Binary::from(msg.as_bytes())),
+            None => None,
+        };
+        let finality_msg = match &self.finality_msg {
+            Some(msg) => Some(Binary::from(msg.as_bytes())),
+            None => None,
+        };
         let contract = app
             .instantiate_contract(
                 contract_code_id,
@@ -148,7 +144,7 @@ impl SuiteBuilder {
                     btc_confirmation_depth: 1,
                     checkpoint_finalization_timeout,
                     btc_light_client_code_id: Some(btc_light_client_code_id),
-                    btc_light_client_msg: Some(light_client_msg),
+                    btc_light_client_msg: light_client_msg,
                     btc_staking_code_id: Some(btc_staking_code_id),
                     btc_staking_msg: staking_msg,
                     btc_finality_code_id: Some(btc_finality_code_id),

--- a/contracts/babylon/src/multitest/suite.rs
+++ b/contracts/babylon/src/multitest/suite.rs
@@ -1,9 +1,8 @@
 use crate::msg::ibc::TransferInfoResponse;
 use anyhow::Result as AnyResult;
 use babylon_bindings_test::BabylonApp;
-use btc_light_client::msg::InstantiateMsg as BtcLightClientInstantiateMsg;
 use btc_light_client::BitcoinNetwork;
-use cosmwasm_std::{to_json_binary, Addr, Binary, Empty};
+use cosmwasm_std::{Addr, Binary, Empty};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
 use derivative::Derivative;
 
@@ -104,8 +103,13 @@ impl SuiteBuilder {
     pub fn build(self) -> Suite {
         let _funds = self.funds;
 
-        let owner = Addr::unchecked("owner");
+        // Create a BabylonApp first to get access to the API
+        let app = BabylonApp::new("temp");
 
+        // Use the app's API to generate a proper bech32 address
+        let owner = app.api().addr_make("owner");
+
+        // Now recreate the app with the proper owner
         let mut app = BabylonApp::new(owner.as_str());
 
         let _block_info = app.block_info();

--- a/contracts/btc-finality/Cargo.toml
+++ b/contracts/btc-finality/Cargo.toml
@@ -50,9 +50,6 @@ thiserror        = { workspace = true }
 cw-controllers   = { workspace = true }
 
 [dev-dependencies]
-babylon-contract      = { path = "../babylon", features = [ "library" ] }
-btc-staking           = { path = "../btc-staking", features = [ "library" ] }
-
 babylon-bindings-test = { path = "../../packages/bindings-test" }
 babylon-proto         = { path = "../../packages/proto" }
 babylon-test-utils    = { path = "../../packages/test-utils" }

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -17,8 +17,8 @@ use babylon_apis::finality_api::SudoMsg;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    attr, coin, to_json_binary, Addr, CustomQuery, Deps, DepsMut, Empty, Env, MessageInfo,
-    QueryRequest, QueryResponse, Reply, Response, StdResult, Uint128, WasmMsg, WasmQuery,
+    attr, to_json_binary, Addr, CustomQuery, Deps, DepsMut, Empty, Env, MessageInfo, QueryRequest,
+    QueryResponse, Reply, Response, StdResult, WasmQuery,
 };
 use cw2::set_contract_version;
 use cw_utils::{maybe_addr, nonpayable};
@@ -287,8 +287,9 @@ pub(crate) mod tests {
     use super::*;
 
     use cosmwasm_std::{
-        coins, from_json,
+        coin, coins, from_json,
         testing::{message_info, mock_dependencies, mock_env},
+        Uint128, WasmMsg,
     };
     use cw_controllers::AdminResponse;
     pub(crate) const CREATOR: &str = "creator";

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -7,17 +7,7 @@ use {
     cw_controllers::AdminResponse,
 };
 
-#[cw_serde]
-#[derive(Default)]
-pub struct InstantiateMsg {
-    pub admin: Option<String>,
-    pub max_active_finality_providers: Option<u32>,
-    pub min_pub_rand: Option<u64>,
-    pub reward_interval: Option<u64>,
-    pub missed_blocks_window: Option<u64>,
-    pub jail_duration: Option<u64>,
-}
-
+pub type InstantiateMsg = babylon_apis::finality_api::InstantiateMsg;
 pub type ExecuteMsg = babylon_apis::finality_api::ExecuteMsg;
 
 #[cw_serde]

--- a/contracts/btc-staking/src/msg.rs
+++ b/contracts/btc-staking/src/msg.rs
@@ -7,11 +7,7 @@ use {
     cw_controllers::AdminResponse,
 };
 
-#[cw_serde]
-#[derive(Default)]
-pub struct InstantiateMsg {
-    pub admin: Option<String>,
-}
+pub type InstantiateMsg = babylon_apis::btc_staking_api::InstantiateMsg;
 
 pub type ExecuteMsg = babylon_apis::btc_staking_api::ExecuteMsg;
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -110,6 +110,9 @@ func (s *BabylonSDKTestSuite) Test1ContractDeployment() {
 	s.NoError(err)
 	s.NotEmpty(configResp)
 	s.Equal(configResp["babylon_contract_address"], s.ConsumerContract.Babylon.String())
+	// TODO: why this is float64 even though it's u32 in rust
+	s.Equal(configResp["btc_confirmation_depth"], float64(1))
+	s.Equal(configResp["checkpoint_finalization_timeout"], float64(2))
 }
 
 func (s *BabylonSDKTestSuite) Test2InsertBTCHeaders() {

--- a/e2e/types/test_client.go
+++ b/e2e/types/test_client.go
@@ -215,9 +215,9 @@ func (p *TestConsumerClient) deployContracts() (*ConsumerContract, error) {
 	ics20ChannelID := "channel-1"
 
 	// Create init messages for other contracts
-	btcLightClientInitMsg := NewBTCLightClientInitMsg(admin, network, kValue, wValue)
-	btcStakingInitMsg := NewBTCStakingInitMsg(admin)
-	btcFinalityInitMsg := NewBTCFinalityInitMsg(admin)
+	btcLightClientInitMsg := []byte{}
+	btcStakingInitMsg := []byte{}
+	btcFinalityInitMsg := []byte{}
 
 	// Build the Babylon contract instantiation message
 	babylonInitMsg := NewBabylonInitMsg(

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -89,16 +89,23 @@ func NewBabylonInitMsg(
 		"btc_confirmation_depth":          k,
 		"checkpoint_finalization_timeout": w,
 		"btc_light_client_code_id":        btcLightClientCodeID,
-		"btc_light_client_msg":            base64.StdEncoding.EncodeToString(btcLightClientInitMsg),
 		"btc_staking_code_id":             btcStakingCodeID,
-		"btc_staking_msg":                 base64.StdEncoding.EncodeToString(btcStakingInitMsg),
 		"btc_finality_code_id":            btcFinalityCodeID,
-		"btc_finality_msg":                base64.StdEncoding.EncodeToString(btcFinalityInitMsg),
 		"admin":                           admin,
 		"consumer_name":                   consumerName,
 		"consumer_description":            consumerDescription,
 		"ics20_channel_id":                ics20ChannelID,
 		"destination_module":              "btcstaking",
+	}
+
+	if len(btcLightClientInitMsg) > 0 {
+		data["btc_light_client_msg"] = base64.StdEncoding.EncodeToString(btcLightClientInitMsg)
+	}
+	if len(btcStakingInitMsg) > 0 {
+		data["btc_staking_msg"] = base64.StdEncoding.EncodeToString(btcStakingInitMsg)
+	}
+	if len(btcFinalityInitMsg) > 0 {
+		data["btc_finality_msg"] = base64.StdEncoding.EncodeToString(btcFinalityInitMsg)
 	}
 
 	jsonBytes, err := json.Marshal(data)

--- a/packages/apis/src/btc_staking_api.rs
+++ b/packages/apis/src/btc_staking_api.rs
@@ -8,6 +8,12 @@ use cosmwasm_std::Binary;
 pub const HASH_SIZE: usize = 32;
 
 #[cw_serde]
+#[derive(Default)]
+pub struct InstantiateMsg {
+    pub admin: Option<String>,
+}
+
+#[cw_serde]
 /// btc_staking execution handlers
 pub enum ExecuteMsg {
     /// Change the admin

--- a/packages/apis/src/finality_api.rs
+++ b/packages/apis/src/finality_api.rs
@@ -9,6 +9,17 @@ use babylon_merkle::Proof;
 use crate::Bytes;
 
 #[cw_serde]
+#[derive(Default)]
+pub struct InstantiateMsg {
+    pub admin: Option<String>,
+    pub max_active_finality_providers: Option<u32>,
+    pub min_pub_rand: Option<u64>,
+    pub reward_interval: Option<u64>,
+    pub missed_blocks_window: Option<u64>,
+    pub jail_duration: Option<u64>,
+}
+
+#[cw_serde]
 /// babylon_finality execution handlers
 pub enum ExecuteMsg {
     /// Change the admin


### PR DESCRIPTION
Part of https://github.com/babylonlabs-io/pm/issues/461

This PR provides a minor refactoring of the instantiation messages for contracts. In particular, it 

- sets the consumer name/description outside of the if statements
- gives option to leave empty instantiation messages for BTC {light client, staking, finality} contracts
- if these instantiation messages are left empty, the handler will use values inside Babylon contract's instantiation message (which is recommended)

This PR also adapts e2e test to test this