### PR TITLE
chore: impl `gen_random_msg_commit_pub_rand()` properly and re-enable EOTS sig check in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 [Full Changelog](https://github.com/babylonlabs-io/cosmos-bsn-contracts/compare/v0.16.0...HEAD)
 
+### Improvements
+
+- [#311](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/311) chore: impl `gen_random_msg_commit_pub_rand()` properly and re-enable EOTS sig check in tests
+
 ## [v0.16.0](https://github.com/babylonlabs-io/cosmos-bsn-contracts/tree/v0.16.0) (2025-08-07)
 
 [Full Changelog](https://github.com/babylonlabs-io/cosmos-bsn-contracts/compare/v0.15.2...v0.16.0)

--- a/contracts/btc-finality/Cargo.toml
+++ b/contracts/btc-finality/Cargo.toml
@@ -53,6 +53,7 @@ cw-controllers   = { workspace = true }
 babylon-bindings-test = { path = "../../packages/bindings-test" }
 babylon-proto         = { path = "../../packages/proto" }
 babylon-test-utils    = { path = "../../packages/test-utils" }
+eots                  = { path = "../../packages/eots", features = ["rand"] }
 
 cosmwasm-vm           = { workspace = true }
 cw-multi-test         = { workspace = true }

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -86,24 +86,12 @@ pub fn handle_public_randomness_commit(
             ContractError::FinalityProviderNotFound(pub_rand_commit.fp_btc_pk_hex.clone())
         })?;
 
-    #[cfg(test)]
-    let verify_signature = || -> Result<(), PubRandCommitError> {
-        // TODO: Skip the signature verification in tests until we can generate proper MsgPubRandCommit
-        // by probably adpating `crate::tests::gen_random_msg_commit_pub_rand()`.
-        Ok(())
-    };
+    let signing_context = babylon_apis::signing_context::fp_rand_commit_context_v0(
+        &env.block.chain_id,
+        env.contract.address.as_str(),
+    );
 
-    #[cfg(not(test))]
-    let verify_signature = || -> Result<(), PubRandCommitError> {
-        let signing_context = babylon_apis::signing_context::fp_rand_commit_context_v0(
-            &env.block.chain_id,
-            env.contract.address.as_str(),
-        );
-
-        pub_rand_commit.verify_sig(signing_context)
-    };
-
-    verify_signature()?;
+    pub_rand_commit.verify_sig(signing_context)?;
 
     // Get last public randomness commitment
     // TODO: allow committing public randomness earlier than existing ones?

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -1,4 +1,4 @@
-use crate::error::{ContractError, FinalitySigError, PubRandCommitError};
+use crate::error::{ContractError, FinalitySigError};
 use crate::msg::{MsgAddFinalitySig, MsgCommitPubRand};
 use crate::power_dist_change::JAIL_FOREVER;
 use crate::state::config::{ADMIN, CONFIG};

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -84,6 +84,16 @@ impl MsgCommitPubRand {
 
         Ok(())
     }
+
+    #[cfg(test)]
+    pub fn as_pub_rand_commit(&self, height: u64) -> PubRandCommit {
+        PubRandCommit {
+            start_height: self.start_height,
+            num_pub_rand: self.num_pub_rand,
+            height,
+            commitment: self.commitment.clone().into(),
+        }
+    }
 }
 
 pub(crate) fn commit_pub_rand_signed_message(

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -84,9 +84,7 @@ fn commit_public_randomness_works() {
     assert_eq!(
         suite
             .commit_public_randomness(&bad_pk_hex, &pub_rand, &pubrand_signature)
-            .unwrap_err()
-            .downcast::<ContractError>()
-            .unwrap(),
+            .unwrap_err(),
         ContractError::FinalityProviderNotFound(bad_pk_hex)
     );
 
@@ -96,9 +94,7 @@ fn commit_public_randomness_works() {
     assert_eq!(
         suite
             .commit_public_randomness(&pk_hex, &bad_pub_rand_commit, &pubrand_signature)
-            .unwrap_err()
-            .downcast::<ContractError>()
-            .unwrap(),
+            .unwrap_err(),
         ContractError::TooFewPubRand(3, 1)
     );
 
@@ -148,15 +144,11 @@ fn commit_public_randomness_works() {
         overlapped_start_height,
         pub_rand.num_pub_rand,
     );
-    let pk_hex = msg_pub_rand_commit.fp_btc_pk_hex.clone();
-
     let bad_pub_rand_commit = msg_pub_rand_commit.as_pub_rand_commit(block_info.height);
     assert_eq!(
         suite
             .commit_public_randomness(&pk_hex, &bad_pub_rand_commit, &msg_pub_rand_commit.sig)
-            .unwrap_err()
-            .downcast::<ContractError>()
-            .unwrap(),
+            .unwrap_err(),
         ContractError::InvalidPubRandHeight(
             bad_pub_rand_commit.start_height,
             last_pub_rand.end_height(),
@@ -185,9 +177,7 @@ fn commit_public_randomness_works() {
     assert_eq!(
         suite
             .commit_public_randomness(&pk_hex, &bad_pub_rand_commit, &pubrand_signature)
-            .unwrap_err()
-            .downcast::<ContractError>()
-            .unwrap(),
+            .unwrap_err(),
         PubRandCommitError::OverflowInBlockHeight(
             bad_pub_rand_commit.start_height,
             bad_pub_rand_commit.num_pub_rand,
@@ -201,9 +191,7 @@ fn commit_public_randomness_works() {
     assert!(matches!(
         suite
             .commit_public_randomness(&pk_hex, &bad_pub_rand_commit, &pubrand_signature)
-            .unwrap_err()
-            .downcast::<ContractError>()
-            .unwrap(),
+            .unwrap_err(),
         ContractError::FuturePubRandStartHeight { .. }
     ));
 }

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -1,3 +1,4 @@
+use crate::error::ContractError;
 use crate::msg::QueryMsg as FinalityQueryMsg;
 use crate::msg::{
     ActiveFinalityProvidersResponse, EvidenceResponse, FinalityProviderPowerResponse,
@@ -367,19 +368,21 @@ impl Suite {
         pk_hex: &str,
         pub_rand: &PubRandCommit,
         pubrand_signature: &[u8],
-    ) -> anyhow::Result<AppResponse> {
-        self.app.execute_contract(
-            Addr::unchecked(USER_ADDR),
-            self.finality.clone(),
-            &finality_api::ExecuteMsg::CommitPublicRandomness {
-                fp_pubkey_hex: pk_hex.to_string(),
-                start_height: pub_rand.start_height,
-                num_pub_rand: pub_rand.num_pub_rand,
-                commitment: pub_rand.commitment.clone().into(),
-                signature: pubrand_signature.into(),
-            },
-            &[],
-        )
+    ) -> Result<AppResponse, ContractError> {
+        self.app
+            .execute_contract(
+                Addr::unchecked(USER_ADDR),
+                self.finality.clone(),
+                &finality_api::ExecuteMsg::CommitPublicRandomness {
+                    fp_pubkey_hex: pk_hex.to_string(),
+                    start_height: pub_rand.start_height,
+                    num_pub_rand: pub_rand.num_pub_rand,
+                    commitment: pub_rand.commitment.clone().into(),
+                    signature: pubrand_signature.into(),
+                },
+                &[],
+            )
+            .map_err(|e| e.downcast::<ContractError>().unwrap())
     }
 
     #[track_caller]

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -182,7 +182,7 @@ impl SuiteBuilder {
 #[derivative(Debug)]
 pub struct Suite {
     #[derivative(Debug = "ignore")]
-    app: BabylonApp,
+    pub app: BabylonApp,
     /// The code id of the babylon contract
     code_id: u64,
     /// Babylon contract address

--- a/contracts/btc-finality/src/tests.rs
+++ b/contracts/btc-finality/src/tests.rs
@@ -7,6 +7,15 @@ use babylon_merkle::Proof;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
+struct MsgTestCase<Msg, MsgErr> {
+    name: &'static str,
+    msg_modifier: fn(&mut Msg),
+    expected: Result<(), MsgErr>,
+}
+
+type MsgCommitPubRandTestCase = MsgTestCase<MsgCommitPubRand, PubRandCommitError>;
+type MsgAddFinalitySigTestCase = MsgTestCase<MsgAddFinalitySig, FinalitySigError>;
+
 // Helper function to generate random bytes
 fn gen_random_bytes(rng: &mut StdRng, len: usize) -> Vec<u8> {
     (0..len).map(|_| rng.gen()).collect()
@@ -18,15 +27,6 @@ fn gen_random_btc_key_bytes(rng: &mut StdRng) -> (Vec<u8>, Vec<u8>) {
     let pk = gen_random_bytes(rng, 32);
     (sk, pk)
 }
-
-struct MsgTestCase<Msg, MsgErr> {
-    name: &'static str,
-    msg_modifier: fn(&mut Msg),
-    expected: Result<(), MsgErr>,
-}
-
-type MsgCommitPubRandTestCase = MsgTestCase<MsgCommitPubRand, PubRandCommitError>;
-type MsgAddFinalitySigTestCase = MsgTestCase<MsgAddFinalitySig, FinalitySigError>;
 
 // Helper function to generate random message
 fn gen_random_msg_commit_pub_rand(

--- a/contracts/btc-finality/src/tests.rs
+++ b/contracts/btc-finality/src/tests.rs
@@ -60,8 +60,7 @@ pub(crate) fn gen_random_msg_commit_pub_rand(
 
     let fp_btc_pk_hex = hex::encode(&verifying_key_bytes);
 
-    let btc_pk_raw = hex::decode(&fp_btc_pk_hex).unwrap();
-    let btc_pk = VerifyingKey::from_bytes(&btc_pk_raw).unwrap();
+    let btc_pk = VerifyingKey::from_bytes(&verifying_key_bytes).unwrap();
     let sig_to_verify = Signature::try_from(sig.as_slice()).unwrap();
 
     btc_pk

--- a/packages/eots/Cargo.toml
+++ b/packages/eots/Cargo.toml
@@ -11,9 +11,13 @@ publish           = true
 [dependencies]
 hex         = { workspace = true }
 k256        = { workspace = true }
+rand        = { workspace = true, optional = true }
 sha2        = { workspace = true }
 thiserror   = { workspace = true }
 
 [dev-dependencies]
 babylon-test-utils = { path = "../../packages/test-utils" }
 rand               = { workspace = true }
+
+[features]
+rand = ["dep:rand"]

--- a/packages/eots/src/eots.rs
+++ b/packages/eots/src/eots.rs
@@ -80,6 +80,7 @@ impl Deref for PrivateRand {
 
 /// `PubRand` is the type for a public randomness.
 /// It is formed as a point on the secp256k1 curve
+#[derive(Clone, Copy, Debug)]
 pub struct PubRand {
     inner: ProjectivePoint,
 }
@@ -126,7 +127,7 @@ impl PubRand {
         }
     }
 
-    fn to_x_bytes(&self) -> Vec<u8> {
+    pub fn to_x_bytes(&self) -> Vec<u8> {
         point_to_x_bytes(&self.inner).to_vec()
     }
 }
@@ -494,6 +495,17 @@ impl PublicKey {
     }
 }
 
+/// Generate a random pair of (PrivateRand, PubRand).
+#[cfg(any(test, feature = "rand"))]
+pub fn rand_gen() -> (PrivateRand, PubRand) {
+    let random_bytes: [u8; 32] = Scalar::generate_vartime(&mut rand::thread_rng())
+        .to_bytes()
+        .into();
+    let x = PrivateRand::new(&random_bytes).unwrap();
+    let p = PubRand::from(ProjectivePoint::mul_by_generator(&*x));
+    (x, p)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -501,15 +513,6 @@ mod tests {
     use k256::{ProjectivePoint, Scalar};
     use rand::{thread_rng, RngCore};
     use sha2::{Digest, Sha256};
-
-    pub fn rand_gen() -> (PrivateRand, PubRand) {
-        let random_bytes: [u8; 32] = Scalar::generate_vartime(&mut thread_rng())
-            .to_bytes()
-            .into();
-        let x = PrivateRand::new(&random_bytes).unwrap();
-        let p = PubRand::from(ProjectivePoint::mul_by_generator(&*x));
-        (x, p)
-    }
 
     impl Default for SecretKey {
         fn default() -> Self {

--- a/packages/eots/src/eots.rs
+++ b/packages/eots/src/eots.rs
@@ -495,7 +495,7 @@ impl PublicKey {
     }
 }
 
-/// Generate a random pair of (PrivateRand, PubRand).
+/// Generate a random pair of (PrivateRand, PubRand) for testing purpose.
 #[cfg(any(test, feature = "rand"))]
 pub fn rand_gen() -> (PrivateRand, PubRand) {
     let random_bytes: [u8; 32] = Scalar::generate_vartime(&mut rand::thread_rng())

--- a/packages/eots/src/lib.rs
+++ b/packages/eots/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod eots;
 pub mod error;
 
+#[cfg(feature = "rand")]
+pub use eots::rand_gen;
 pub use eots::{tagged_hash, PrivateRand, PubRand, PublicKey, SecretKey, Signature, CHALLENGE_TAG};
 pub use error::Error;
 pub type Result<T> = std::result::Result<T, Error>;

--- a/packages/merkle/src/hash.rs
+++ b/packages/merkle/src/hash.rs
@@ -5,6 +5,10 @@ use sha2::{Digest, Sha256};
 const LEAF_PREFIX: u8 = 0;
 const INNER_PREFIX: u8 = 1;
 
+pub(crate) fn empty_hash() -> Vec<u8> {
+    Sha256::digest([]).to_vec()
+}
+
 /// tmhash(0x00 || leaf)
 pub(crate) fn leaf_hash(leaf: &[u8]) -> Vec<u8> {
     let mut hasher = Sha256::new();
@@ -20,4 +24,19 @@ pub(crate) fn inner_hash(left: &[u8], right: &[u8]) -> Vec<u8> {
     hasher.update(left);
     hasher.update(right);
     hasher.finalize().to_vec()
+}
+
+pub(crate) fn leaf_hash_opt(hasher: &mut Sha256, leaf: &[u8]) -> Vec<u8> {
+    hasher.reset();
+    hasher.update([LEAF_PREFIX]);
+    hasher.update(leaf);
+    hasher.finalize_reset().to_vec()
+}
+
+pub(crate) fn inner_hash_opt(hasher: &mut Sha256, left: &[u8], right: &[u8]) -> Vec<u8> {
+    hasher.reset();
+    hasher.update([INNER_PREFIX]);
+    hasher.update(left);
+    hasher.update(right);
+    hasher.finalize_reset().to_vec()
 }

--- a/packages/merkle/src/lib.rs
+++ b/packages/merkle/src/lib.rs
@@ -22,3 +22,4 @@ mod tree;
 
 pub use self::error::MerkleError;
 pub use self::proof::Proof;
+pub use self::tree::hash_from_byte_slices;

--- a/packages/merkle/src/tree.rs
+++ b/packages/merkle/src/tree.rs
@@ -1,6 +1,29 @@
 //! https://github.com/cometbft/cometbft/blob/v0.38.17/crypto/merkle/tree.go
 
 use crate::error::MerkleError;
+use crate::hash::{empty_hash, inner_hash_opt, leaf_hash_opt};
+use sha2::{Digest, Sha256};
+
+/// Computes a Merkle tree where the leaves are the byte slice,
+/// in the provided order. It follows RFC-6962.
+///
+/// https://github.com/cometbft/cometbft/blob/d03254d3599b973f979314e6383b89fa1802e679/crypto/merkle/tree.go#L11
+pub fn hash_from_byte_slices(items: Vec<Vec<u8>>) -> Vec<u8> {
+    hash_from_byte_slices_internal(&mut Sha256::new(), items)
+}
+
+fn hash_from_byte_slices_internal(sha: &mut Sha256, items: Vec<Vec<u8>>) -> Vec<u8> {
+    match items.len() {
+        0 => empty_hash(),
+        1 => leaf_hash_opt(sha, &items[0]),
+        _ => {
+            let k = get_split_point(items.len() as u64).unwrap() as usize;
+            let left = hash_from_byte_slices_internal(sha, items[..k].to_vec());
+            let right = hash_from_byte_slices_internal(sha, items[k..].to_vec());
+            inner_hash_opt(sha, &left, &right)
+        }
+    }
+}
 
 /// Returns the largest power of 2 less than length.
 pub(crate) fn get_split_point(length: u64) -> Result<u64, MerkleError> {

--- a/packages/merkle/src/tree.rs
+++ b/packages/merkle/src/tree.rs
@@ -9,17 +9,17 @@ use sha2::{Digest, Sha256};
 ///
 /// https://github.com/cometbft/cometbft/blob/d03254d3599b973f979314e6383b89fa1802e679/crypto/merkle/tree.go#L11
 pub fn hash_from_byte_slices(items: Vec<Vec<u8>>) -> Vec<u8> {
-    hash_from_byte_slices_internal(&mut Sha256::new(), items)
+    hash_from_byte_slices_internal(&mut Sha256::new(), &items)
 }
 
-fn hash_from_byte_slices_internal(sha: &mut Sha256, items: Vec<Vec<u8>>) -> Vec<u8> {
+fn hash_from_byte_slices_internal(sha: &mut Sha256, items: &[Vec<u8>]) -> Vec<u8> {
     match items.len() {
         0 => empty_hash(),
         1 => leaf_hash_opt(sha, &items[0]),
         _ => {
             let k = get_split_point(items.len() as u64).unwrap() as usize;
-            let left = hash_from_byte_slices_internal(sha, items[..k].to_vec());
-            let right = hash_from_byte_slices_internal(sha, items[k..].to_vec());
+            let left = hash_from_byte_slices_internal(sha, &items[..k]);
+            let right = hash_from_byte_slices_internal(sha, &items[k..]);
             inner_hash_opt(sha, &left, &right)
         }
     }


### PR DESCRIPTION
This PR re-enables the EOTS signature check in tests, no logical changes in the production. It also adds back the code deleted in #258 for generating the commitment for the pub randomness list.

Resolves https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/304#discussion_r2258731544