### PR TITLE
chore: add preliminary `test_add_finality_sig()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#322](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/322) chore: add preliminary `test_add_finality_sig()`
 - [#318](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/318) chore: port `TestGetPubRandCommitForHeight` and tallying test
 - [#317](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/317) finality: add tests for voting power rotation
 - [#315](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/315) refactor: unify imports and update CI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
  "babylon-proto",
  "babylon-test-utils",
  "bitcoin",
+ "btc-finality",
  "btc-light-client",
  "btc-staking",
  "cosmwasm-schema",

--- a/contracts/btc-finality/Cargo.toml
+++ b/contracts/btc-finality/Cargo.toml
@@ -25,6 +25,7 @@ default = []
 cranelift = ["cosmwasm-vm/cranelift"]
 # for quicker tests, cargo test --lib
 library = []
+testing = ["babylon-apis/testing"]
 
 [dependencies]
 babylon-apis          = { path = "../../packages/apis" }
@@ -50,6 +51,7 @@ thiserror        = { workspace = true }
 cw-controllers   = { workspace = true }
 
 [dev-dependencies]
+btc-finality          = { path = ".", features = ["testing"] }
 babylon-bindings-test = { path = "../../packages/bindings-test" }
 babylon-proto         = { path = "../../packages/proto" }
 babylon-test-utils    = { path = "../../packages/test-utils" }

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -244,11 +244,7 @@ fn handle_update_staking(
 }
 
 fn handle_begin_block(deps: &mut DepsMut, env: Env) -> Result<Response, ContractError> {
-    // Compute active finality provider set
-    let max_active_fps = CONFIG.load(deps.storage)?.max_active_finality_providers as usize;
-    let response = compute_active_finality_providers(deps, &env, max_active_fps)?;
-
-    Ok(response)
+    compute_active_finality_providers(deps, &env)
 }
 
 fn handle_end_block(

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -196,6 +196,19 @@ pub fn execute(
             },
         ),
         ExecuteMsg::Unjail { fp_pubkey_hex } => handle_unjail(deps, &env, &info, &fp_pubkey_hex),
+        #[cfg(any(test, feature = "testing"))]
+        ExecuteMsg::SetPowerTable {
+            fp_pubkey_hex,
+            height,
+            power,
+        } => {
+            crate::state::finality::FP_POWER_TABLE.save(
+                deps.storage,
+                (height, fp_pubkey_hex.as_str()),
+                &power,
+            )?;
+            Ok(Response::new())
+        }
     }
 }
 

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -2,8 +2,7 @@ pub mod suite;
 
 use crate::error::{ContractError, PubRandCommitError};
 use crate::msg::{FinalitySignatureResponse, JailedFinalityProvider};
-use crate::state::finality::FP_POWER_TABLE;
-use crate::state::finality::{get_fp_power, get_power_table_at_height};
+use crate::state::finality::{get_fp_power, FP_POWER_TABLE};
 use crate::tests::gen_random_msg_commit_pub_rand;
 use babylon_apis::finality_api::IndexedBlock;
 use babylon_bindings_test::{
@@ -196,6 +195,7 @@ fn commit_public_randomness_works() {
     ));
 }
 
+// TODO: complete `FuzzAddFinalitySig`.
 #[test]
 fn test_add_finality_sig() {
     // Read public randomness commitment test data
@@ -291,6 +291,23 @@ fn test_add_finality_sig() {
             .unwrap_err(),
         ContractError::MissingPubRandCommit(pk_hex.clone(), block_height2)
     );
+
+    suite
+        .set_power_table(&pk_hex, initial_height + 1, 1)
+        .unwrap();
+
+    let _result = suite.submit_finality_signature(
+        &pk_hex,
+        initial_height + 1,
+        &pub_rand_one,
+        &proof,
+        &add_finality_signature.block_app_hash,
+        &add_finality_signature.finality_sig,
+    );
+
+    // TODO: why it failed to be submitted?
+    // result: Err(PubRandCommitNotBTCTimestamped("The finality provider db34109af277bdb0b0d643f97190730217538f8643cafd4005a633903a1ea03d last committed height: 102, last finalized height: 100"))
+    // assert!(result.is_ok());
 }
 
 #[test]

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -195,6 +195,98 @@ fn commit_public_randomness_works() {
 }
 
 #[test]
+fn test_add_finality_sig() {
+    // Read public randomness commitment test data
+    let (pk_hex, pub_rand, pubrand_signature) = get_public_randomness_commitment();
+    let pub_rand_one = get_pub_rand_value();
+    // Read equivalent / consistent add finality signature test data
+    let add_finality_signature = get_add_finality_sig();
+    let proof = add_finality_signature.proof.unwrap();
+
+    let initial_height = pub_rand.start_height;
+    let initial_funds = &[coin(1_000_000, "TOKEN")];
+
+    let mut suite = SuiteBuilder::new()
+        .with_height(initial_height)
+        .with_funds(initial_funds)
+        .build();
+
+    // Register one FP
+    // NOTE: the test data ensures that pub rand commit / finality sig are
+    // signed by the 1st FP
+    let new_fp = create_new_finality_provider(1);
+
+    suite.register_finality_providers(&[new_fp]).unwrap();
+
+    // Add a delegation, so that the finality provider has some power
+    let mut del1 = get_derived_btc_delegation(1, &[1]);
+    del1.fp_btc_pk_list = vec![pk_hex.clone()];
+
+    suite.add_delegations(&[del1]).unwrap();
+
+    suite
+        .commit_public_randomness(&pk_hex, &pub_rand, &pubrand_signature)
+        .unwrap();
+
+    // Call the begin-block sudo handler(s), for completeness
+    let res = suite
+        .call_begin_block(&add_finality_signature.block_app_hash, initial_height + 1)
+        .unwrap();
+    assert_eq!(2, res.events.len());
+    assert_eq!(
+        res.events[0],
+        Event::new("sudo").add_attribute("_contract_address", BTC_FINALITY_CONTRACT_ADDR)
+    );
+    // Check the finality provider status change event
+    assert_eq!(
+        res.events[1],
+        Event::new("wasm-finality_provider_status_change")
+            .add_attribute("_contract_address", BTC_FINALITY_CONTRACT_ADDR)
+            .add_attribute("btc_pk", &pk_hex)
+            .add_attribute("new_state", "FINALITY_PROVIDER_STATUS_ACTIVE")
+    );
+
+    // Call the end-block sudo handler(s), so that the block is indexed in the store
+    let res = suite
+        .call_end_block(&add_finality_signature.block_app_hash, initial_height + 1)
+        .unwrap();
+    assert_eq!(2, res.events.len());
+    assert_eq!(
+        res.events[0],
+        Event::new("sudo").add_attribute("_contract_address", BTC_FINALITY_CONTRACT_ADDR)
+    );
+    assert_eq!(
+        res.events[1],
+        Event::new("wasm-index_block")
+            .add_attribute("_contract_address", BTC_FINALITY_CONTRACT_ADDR)
+            .add_attribute("module", "finality")
+            .add_attribute("last_height", (initial_height + 1).to_string())
+    );
+
+    // Submit a finality signature from that finality provider at height initial_height + 1
+    let finality_sig = add_finality_signature.finality_sig.to_vec();
+    suite
+        .submit_finality_signature(
+            &pk_hex,
+            initial_height + 1,
+            &pub_rand_one,
+            &proof,
+            &add_finality_signature.block_app_hash,
+            &finality_sig,
+        )
+        .unwrap();
+
+    // Query finality signature for that exact height
+    let sig = suite.get_finality_signature(&pk_hex, initial_height + 1);
+    assert_eq!(
+        sig,
+        FinalitySignatureResponse {
+            signature: finality_sig
+        }
+    );
+}
+
+#[test]
 fn finality_signature_happy_path() {
     // Read public randomness commitment test data
     let (pk_hex, pub_rand, pubrand_signature) = get_public_randomness_commitment();
@@ -759,3 +851,4 @@ fn offline_fps_are_jailed() {
     assert_eq!(active_fps.len(), 1);
     assert!(active_fps.contains_key(&new_fp1.btc_pk_hex));
 }
+

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -459,6 +459,31 @@ impl Suite {
     }
 
     #[track_caller]
+    pub fn set_power_table(
+        &mut self,
+        pk_hex: &str,
+        height: u64,
+        power: u64,
+    ) -> Result<AppResponse, ContractError> {
+        let mut block = self.app.block_info();
+        block.height = height + 1;
+        self.app.set_block(block);
+
+        self.app
+            .execute_contract(
+                Addr::unchecked(USER_ADDR),
+                self.finality.clone(),
+                &finality_api::ExecuteMsg::SetPowerTable {
+                    fp_pubkey_hex: pk_hex.to_string(),
+                    height,
+                    power,
+                },
+                &[],
+            )
+            .map_err(|e| e.downcast::<ContractError>().unwrap())
+    }
+
+    #[track_caller]
     pub fn unjail(&mut self, sender: &str, fp_pubkey_hex: &str) -> AnyResult<AppResponse> {
         self.app.execute_contract(
             Addr::unchecked(sender),

--- a/contracts/btc-finality/src/power_dist_change.rs
+++ b/contracts/btc-finality/src/power_dist_change.rs
@@ -22,9 +22,11 @@ pub const JAIL_FOREVER: u64 = 0;
 pub fn compute_active_finality_providers(
     deps: &mut DepsMut,
     env: &Env,
-    max_active_fps: usize,
 ) -> Result<Response, ContractError> {
     let cfg = CONFIG.load(deps.storage)?;
+
+    let max_active_fps = cfg.max_active_finality_providers as usize;
+
     // Get last finalized height (for timestamped public randomness checks)
     let last_finalized_height = get_last_finalized_height(&deps.as_ref())?;
 

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -15,7 +15,7 @@ pub const BLOCKS: Map<u64, IndexedBlock> = Map::new("blocks");
 pub const NEXT_HEIGHT: Item<u64> = Item::new("next_height");
 
 /// `FP_POWER_TABLE` is the map of finality providers to their total active sats at a given height
-const FP_POWER_TABLE: Map<(u64, &str), u64> = Map::new("fp_power_table");
+pub(crate) const FP_POWER_TABLE: Map<(u64, &str), u64> = Map::new("fp_power_table");
 
 /// Map of finality providers to block height they initially entered the active set.
 /// If an FP isn't in this map, he was not in the active finality provider set,

--- a/packages/apis/Cargo.toml
+++ b/packages/apis/Cargo.toml
@@ -17,3 +17,6 @@ cosmwasm-schema  = { workspace = true }
 hex              = { workspace = true }
 thiserror        = { workspace = true }
 sha2             = { workspace = true }
+
+[features]
+testing = []

--- a/packages/apis/src/finality_api.rs
+++ b/packages/apis/src/finality_api.rs
@@ -66,6 +66,12 @@ pub enum ExecuteMsg {
         /// FP to unjail
         fp_pubkey_hex: String,
     },
+    #[cfg(feature = "testing")]
+    SetPowerTable {
+        fp_pubkey_hex: String,
+        height: u64,
+        power: u64,
+    },
 }
 
 /// Represents the necessary metadata and finalization status of a block.


### PR DESCRIPTION
I attempted to port `FuzzAddFinalitySig`, but hit a non-trivial blocker (left a TODO with details). I also dug into cw-multi-test’s contract vs global storage semantics. Let me know if I did something wrong in the process. Given the time sink, I propose we just wrap up #271 for now and shift focus to the broader refactoring and improvements, without breaking changes.

Close #271