### PR TITLE
chore: remove `slashed` from BtcDelegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
-- [#326](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/326) feat: contract migration support
+- [#328](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/328) chore: remove slashed from BtcDelegation
 - [#327](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/327) chore: remove JAIL_FOREVER
+- [#326](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/326) feat: contract migration support
 - [#319](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/319) e2e: add logs and contract pinning support in e2e framework
 - [#318](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/318) chore: port `TestGetPubRandCommitForHeight` and tallying test
 - [#317](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/317) finality: add tests for voting power rotation

--- a/contracts/btc-staking/schema/btc-staking.json
+++ b/contracts/btc-staking/schema/btc-staking.json
@@ -1042,7 +1042,6 @@
             "end_height",
             "fp_btc_pk_list",
             "params_version",
-            "slashed",
             "slashing_tx",
             "staker_addr",
             "staking_output_idx",
@@ -1091,10 +1090,6 @@
               "type": "integer",
               "format": "uint32",
               "minimum": 0.0
-            },
-            "slashed": {
-              "description": "Whether a given delegation is related to a slashed FP.",
-              "type": "boolean"
             },
             "slashing_tx": {
               "description": "Slashing tx in raw bytes.",

--- a/contracts/btc-staking/schema/raw/response_to_delegations.json
+++ b/contracts/btc-staking/schema/raw/response_to_delegations.json
@@ -24,7 +24,6 @@
         "end_height",
         "fp_btc_pk_list",
         "params_version",
-        "slashed",
         "slashing_tx",
         "staker_addr",
         "staking_output_idx",
@@ -73,10 +72,6 @@
           "type": "integer",
           "format": "uint32",
           "minimum": 0.0
-        },
-        "slashed": {
-          "description": "Whether a given delegation is related to a slashed FP.",
-          "type": "boolean"
         },
         "slashing_tx": {
           "description": "Slashing tx in raw bytes.",

--- a/contracts/btc-staking/src/state/staking.rs
+++ b/contracts/btc-staking/src/state/staking.rs
@@ -105,23 +105,17 @@ pub struct BtcDelegation {
     pub undelegation_info: BtcUndelegationInfo,
     /// Params version used to validate the delegation.
     pub params_version: u32,
-    /// Whether a given delegation is related to a slashed FP.
-    pub slashed: bool,
 }
 
 impl BtcDelegation {
     pub fn is_active(&self) -> bool {
         // TODO: Implement full delegation status checks (needs BTC height) (related to #7.2)
         // self.get_status(btc_height, w) == BTCDelegationStatus::ACTIVE
-        !self.is_unbonded_early() && !self.is_slashed()
+        !self.is_unbonded_early()
     }
 
     fn is_unbonded_early(&self) -> bool {
         self.undelegation_info.delegator_unbonding_info.is_some()
-    }
-
-    fn is_slashed(&self) -> bool {
-        self.slashed
     }
 
     pub fn get_status(&self, btc_height: u32, w: u32) -> BTCDelegationStatus {
@@ -130,7 +124,6 @@ impl BtcDelegation {
         if self.is_unbonded_early()
             || btc_height < self.start_height
             || btc_height + w > self.end_height
-            || self.is_slashed()
         {
             BTCDelegationStatus::UNBONDED
         } else {
@@ -174,7 +167,6 @@ impl From<btc_staking_api::ActiveBtcDelegation> for BtcDelegation {
             unbonding_time: active_delegation.unbonding_time,
             undelegation_info: active_delegation.undelegation_info.into(),
             params_version: active_delegation.params_version,
-            slashed: false,
         }
     }
 }


### PR DESCRIPTION
It is a legacy field which should be removed