### PR TITLE
fix: remove unbonding_tx_sig

### DIFF
--- a/contracts/babylon/src/ibc.rs
+++ b/contracts/babylon/src/ibc.rs
@@ -198,7 +198,6 @@ pub(crate) mod ibc_packet {
                 .iter()
                 .map(|u| UnbondedBtcDelegation {
                     staking_tx_hash: u.staking_tx_hash.clone(),
-                    unbonding_tx_sig: u.unbonding_tx_sig.to_vec().into(),
                 })
                 .collect(),
         };

--- a/contracts/btc-staking/src/queries.rs
+++ b/contracts/btc-staking/src/queries.rs
@@ -188,7 +188,7 @@ mod tests {
     use crate::staking::tests::staking_tx_hash;
     use crate::state::staking::{BtcDelegation, FinalityProviderState, FP_STATE_KEY};
     use babylon_apis::btc_staking_api::{FinalityProvider, UnbondedBtcDelegation};
-    use babylon_test_utils::{create_new_finality_provider, get_btc_del_unbonding_sig};
+    use babylon_test_utils::create_new_finality_provider;
     use cosmwasm_std::storage_keys::namespace_with_key;
     use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
     use cosmwasm_std::StdError::NotFound;
@@ -380,13 +380,11 @@ mod tests {
         // Unbond the second delegation
         // Compute staking tx hash
         let staking_tx_hash_hex = staking_tx_hash(&del2.into()).to_string();
-        let unbonding_sig = babylon_test_utils::get_btc_del_unbonding_sig(2, &[1]);
         let msg = ExecuteMsg::BtcStaking {
             new_fp: vec![],
             active_del: vec![],
             unbonded_del: vec![UnbondedBtcDelegation {
                 staking_tx_hash: staking_tx_hash_hex,
-                unbonding_tx_sig: unbonding_sig.to_bytes().into(),
             }],
         };
         execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -520,13 +518,11 @@ mod tests {
         // Unbond the first delegation
         // Compute staking tx hash
         let staking_tx_hash_hex = staking_tx_hash(&del1.into()).to_string();
-        let unbonding_sig = get_btc_del_unbonding_sig(1, &[1]);
         let msg = ExecuteMsg::BtcStaking {
             new_fp: vec![],
             active_del: vec![],
             unbonded_del: vec![UnbondedBtcDelegation {
                 staking_tx_hash: staking_tx_hash_hex,
-                unbonding_tx_sig: unbonding_sig.to_bytes().into(),
             }],
         };
         execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();

--- a/contracts/btc-staking/src/staking.rs
+++ b/contracts/btc-staking/src/staking.rs
@@ -234,7 +234,7 @@ fn handle_undelegation(
     }
 
     // verify the early unbonded delegation
-    verify_undelegation(&cfg, &btc_del, &undelegation.unbonding_tx_sig)?;
+    verify_undelegation(&cfg, &btc_del)?;
 
     // Add the signature to the BTC delegation's undelegation and set back
     btc_undelegate(storage, &staking_tx_hash, &mut btc_del)?;
@@ -448,8 +448,7 @@ pub(crate) mod tests {
     use crate::queries;
     use crate::state::staking::BtcUndelegationInfo;
     use babylon_test_utils::{
-        create_new_finality_provider, get_active_btc_delegation, get_btc_del_unbonding_sig,
-        get_derived_btc_delegation,
+        create_new_finality_provider, get_active_btc_delegation, get_derived_btc_delegation,
     };
     use btc_light_client::msg::btc_header::BtcHeaderResponse;
     use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
@@ -656,12 +655,9 @@ pub(crate) mod tests {
             }
         );
 
-        let unbonding_sig = get_btc_del_unbonding_sig(1, &[1]);
-
         // Now send the undelegation message
         let undelegation = UnbondedBtcDelegation {
             staking_tx_hash: staking_tx_hash_hex.clone(),
-            unbonding_tx_sig: unbonding_sig.to_bytes().into(),
         };
 
         let msg = ExecuteMsg::BtcStaking {

--- a/contracts/btc-staking/src/validation/mod.rs
+++ b/contracts/btc-staking/src/validation/mod.rs
@@ -3,7 +3,6 @@ use crate::state::config::Config;
 use crate::state::staking::BtcDelegation;
 use babylon_apis::btc_staking_api::{ActiveBtcDelegation, NewFinalityProvider};
 use bitcoin::Transaction;
-use cosmwasm_std::Binary;
 
 pub fn verify_new_fp(_new_fp: &NewFinalityProvider) -> Result<(), ContractError> {
     // No-op
@@ -19,11 +18,7 @@ pub fn verify_active_delegation(
     Ok(())
 }
 
-pub fn verify_undelegation(
-    _cfg: &Config,
-    _btc_del: &BtcDelegation,
-    _sig: &Binary,
-) -> Result<(), ContractError> {
+pub fn verify_undelegation(_cfg: &Config, _btc_del: &BtcDelegation) -> Result<(), ContractError> {
     // No-op
     Ok(())
 }

--- a/packages/apis/src/btc_staking_api.rs
+++ b/packages/apis/src/btc_staking_api.rs
@@ -326,9 +326,6 @@ pub struct SignatureInfo {
 pub struct UnbondedBtcDelegation {
     /// Staking tx hash of the BTC delegation. It uniquely identifies a BTC delegation
     pub staking_tx_hash: String,
-    /// Signature on the unbonding tx signed by the BTC delegator
-    /// It proves that the BTC delegator wants to unbond
-    pub unbonding_tx_sig: Binary,
 }
 
 #[cw_serde]

--- a/packages/apis/src/validate.rs
+++ b/packages/apis/src/validate.rs
@@ -107,12 +107,6 @@ impl Validate for UnbondedBtcDelegation {
             return Err(StakingApiError::InvalidStakingTxHash(HASH_SIZE * 2));
         }
 
-        if self.unbonding_tx_sig.is_empty() {
-            return Err(StakingApiError::EmptySignature);
-        }
-
-        // TODO: Verify delegator unbonding Schnorr signature (#7.3)
-
         Ok(())
     }
 }


### PR DESCRIPTION
The ibc packet for [UnbondedBTCDelegation](https://github.com/babylonlabs-io/babylon/blob/753a971c6ab603588611795f5fce0c9cbde2b7ca/x/btcstaking/types/btc_staking_consumer_events.go#L92) is no longer sending `unbonding_tx_sig` anymore. Therefore, `unbonding_tx_sig` should be removed along with empty checks.