### PR TITLE
finality: return jailed FP error explicitly when handling finality signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#335](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/335) finality: return jailed FP error explicitly when handling finality signature
 - [#333](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/333) refactor(btc-light-client): remove dead code
 - [#332](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/332) e2e: e2e test for unbonding
 - [#331](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/331) refactor: introduce `MigrationTester`

--- a/contracts/btc-finality/src/error.rs
+++ b/contracts/btc-finality/src/error.rs
@@ -96,6 +96,8 @@ pub enum ContractError {
     BlockNotFound(u64, String),
     #[error("The finality provider {0} has already been slashed")]
     FinalityProviderAlreadySlashed(String),
+    #[error("The finality provider {0} has already been jailed")]
+    FinalityProviderAlreadyJailed(String),
     #[error("Failed to extract secret key: {0}")]
     SecretKeyExtractionError(String),
     #[error("{0}")]

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -31,6 +31,11 @@ pub const FP_BLOCK_SIGNER: Map<&str, u64> = Map::new("block_signer");
 /// The value is the time in seconds since UNIX epoch when the FP will be released from jail.
 pub const JAIL: Map<&str, u64> = Map::new("jail");
 
+/// Returns whether a finality provider is currently jailed
+pub fn is_fp_jailed(storage: &dyn Storage, fp_btc_pk_hex: &str) -> bool {
+    JAIL.has(storage, fp_btc_pk_hex)
+}
+
 /// Map of double signing evidence by FP and block height
 pub const EVIDENCES: Map<(&str, u64), Evidence> = Map::new("evidences");
 


### PR DESCRIPTION
In line with https://github.com/babylonlabs-io/babylon/blob/2f8df764e05edee36e896e957aa670b196da4d92/x/finality/keeper/msg_server.go#L114-L121