### PR TITLE
fix: avoid generating full-validation contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#336](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/336) fix: avoid generating full-validation contracts
 - [#335](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/335) finality: return jailed FP error explicitly when handling finality signature
 - [#333](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/333) refactor(btc-light-client): remove dead code
 - [#332](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/332) e2e: e2e test for unbonding

--- a/contracts/btc-light-client/Cargo.toml
+++ b/contracts/btc-light-client/Cargo.toml
@@ -9,10 +9,6 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[package.metadata.optimizer]
-default-build = true
-builds = []
-
 [lib]
 crate-type = ["cdylib", "rlib"]
 # See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/contracts/btc-staking/Cargo.toml
+++ b/contracts/btc-staking/Cargo.toml
@@ -9,10 +9,6 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[package.metadata.optimizer]
-default-build = true
-builds = []
-
 [lib]
 crate-type = ["cdylib", "rlib"]
 doctest = false


### PR DESCRIPTION
full-validation contracts will still be generated using optimizer without the change in the PR