### PR TITLE
finality: parameterise max_pub_rand_commit_offset

### DIFF
--- a/contracts/btc-finality/schema/btc-finality.json
+++ b/contracts/btc-finality/schema/btc-finality.json
@@ -37,6 +37,14 @@
         "format": "uint32",
         "minimum": 0.0
       },
+      "max_pub_rand_commit_offset": {
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "uint64",
+        "minimum": 0.0
+      },
       "min_pub_rand": {
         "type": [
           "integer",
@@ -820,6 +828,7 @@
         "finality_activation_height",
         "jail_duration",
         "max_active_finality_providers",
+        "max_pub_rand_commit_offset",
         "min_pub_rand",
         "missed_blocks_window",
         "reward_interval",
@@ -848,6 +857,12 @@
           "description": "Maximum number of active finality providers in the BTC staking protocol.",
           "type": "integer",
           "format": "uint32",
+          "minimum": 0.0
+        },
+        "max_pub_rand_commit_offset": {
+          "description": "Maximum number of blocks into the future that a public randomness commitment start height can target. This limit prevents abuse by capping the size of the commitments index, protecting against potential memory exhaustion or performance degradation caused by excessive future commitments.",
+          "type": "integer",
+          "format": "uint64",
           "minimum": 0.0
         },
         "min_pub_rand": {

--- a/contracts/btc-finality/schema/raw/instantiate.json
+++ b/contracts/btc-finality/schema/raw/instantiate.json
@@ -33,6 +33,14 @@
       "format": "uint32",
       "minimum": 0.0
     },
+    "max_pub_rand_commit_offset": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "min_pub_rand": {
       "type": [
         "integer",

--- a/contracts/btc-finality/schema/raw/response_to_config.json
+++ b/contracts/btc-finality/schema/raw/response_to_config.json
@@ -9,6 +9,7 @@
     "finality_activation_height",
     "jail_duration",
     "max_active_finality_providers",
+    "max_pub_rand_commit_offset",
     "min_pub_rand",
     "missed_blocks_window",
     "reward_interval",
@@ -37,6 +38,12 @@
       "description": "Maximum number of active finality providers in the BTC staking protocol.",
       "type": "integer",
       "format": "uint32",
+      "minimum": 0.0
+    },
+    "max_pub_rand_commit_offset": {
+      "description": "Maximum number of blocks into the future that a public randomness commitment start height can target. This limit prevents abuse by capping the size of the commitments index, protecting against potential memory exhaustion or performance degradation caused by excessive future commitments.",
+      "type": "integer",
+      "format": "uint64",
       "minimum": 0.0
     },
     "min_pub_rand": {

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -8,8 +8,8 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::power_dist_change::compute_active_finality_providers;
 use crate::state::config::{
     Config, ADMIN, CONFIG, DEFAULT_FINALITY_ACTIVATION_HEIGHT, DEFAULT_JAIL_DURATION,
-    DEFAULT_MAX_ACTIVE_FINALITY_PROVIDERS, DEFAULT_MIN_PUB_RAND, DEFAULT_MISSED_BLOCKS_WINDOW,
-    DEFAULT_REWARD_INTERVAL,
+    DEFAULT_MAX_ACTIVE_FINALITY_PROVIDERS, DEFAULT_MAX_PUB_RAND_COMMIT_OFFSET,
+    DEFAULT_MIN_PUB_RAND, DEFAULT_MISSED_BLOCKS_WINDOW, DEFAULT_REWARD_INTERVAL,
 };
 use crate::state::finality::get_btc_staking_activated_height;
 #[cfg(test)]
@@ -52,6 +52,9 @@ pub fn instantiate(
         finality_activation_height: msg
             .finality_activation_height
             .unwrap_or(DEFAULT_FINALITY_ACTIVATION_HEIGHT),
+        max_pub_rand_commit_offset: msg
+            .max_pub_rand_commit_offset
+            .unwrap_or(DEFAULT_MAX_PUB_RAND_COMMIT_OFFSET),
     };
     CONFIG.save(deps.storage, &config)?;
 

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -17,12 +17,6 @@ use cosmwasm_std::{
     coins, to_json_binary, DepsMut, Env, Event, MessageInfo, Response, Uint128, WasmMsg,
 };
 
-// The maximum number of blocks into the future
-// that a public randomness commitment start height can target. This limit prevents abuse by capping
-// the size of the commitments index, protecting against potential memory exhaustion
-// or performance degradation caused by excessive future commitments.
-const MAX_PUB_RAND_COMMIT_OFFSET: u64 = 160_000;
-
 /// Validates that the given height is not lower than the finality activation height.
 /// Returns error if the height received is lower than the finality activation block height.
 fn validate_finality_activation(height: u64, activation_height: u64) -> Result<(), ContractError> {
@@ -48,11 +42,11 @@ pub fn handle_public_randomness_commit(
     validate_finality_activation(pub_rand_commit.start_height, cfg.finality_activation_height)?;
 
     // Check the commit start height is not too far into the future
-    if pub_rand_commit.start_height >= env.block.height + MAX_PUB_RAND_COMMIT_OFFSET {
+    if pub_rand_commit.start_height >= env.block.height + cfg.max_pub_rand_commit_offset {
         return Err(ContractError::FuturePubRandStartHeight {
             start_height: pub_rand_commit.start_height,
             current_height: env.block.height,
-            max_offset: MAX_PUB_RAND_COMMIT_OFFSET,
+            max_offset: cfg.max_pub_rand_commit_offset,
         });
     }
 

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -185,7 +185,7 @@ fn commit_public_randomness_works() {
 
     // Case 7: commit a pubrand list with startHeight too far into the future
     let mut bad_pub_rand_commit = pub_rand.clone();
-    bad_pub_rand_commit.start_height = 500_000;
+    bad_pub_rand_commit.start_height = 2_000_000;
     assert!(matches!(
         suite
             .commit_public_randomness(&pk_hex, &bad_pub_rand_commit, &pubrand_signature)

--- a/contracts/btc-finality/src/state/config.rs
+++ b/contracts/btc-finality/src/state/config.rs
@@ -13,6 +13,7 @@ pub const DEFAULT_MISSED_BLOCKS_WINDOW: u64 = 250;
 pub const DEFAULT_JAIL_DURATION: u64 = 86400;
 /// TODO: set this to 1 for now, but need to revisit this
 pub const DEFAULT_FINALITY_ACTIVATION_HEIGHT: u64 = 1;
+pub const DEFAULT_MAX_PUB_RAND_COMMIT_OFFSET: u64 = 1_600_000;
 
 /// Config are Babylon-selectable BTC finality configuration
 #[cw_serde]
@@ -34,6 +35,10 @@ pub struct Config {
     /// Block height at which the finality module will start to accept finality voting
     /// and the minimum allowed value for the public randomness commit start height.
     pub finality_activation_height: u64,
+    /// Maximum number of blocks into the future that a public randomness commitment start height can target.
+    /// This limit prevents abuse by capping the size of the commitments index, protecting against potential
+    /// memory exhaustion or performance degradation caused by excessive future commitments.
+    pub max_pub_rand_commit_offset: u64,
 }
 
 impl Config {
@@ -49,6 +54,7 @@ impl Config {
             missed_blocks_window: DEFAULT_MISSED_BLOCKS_WINDOW,
             jail_duration: DEFAULT_JAIL_DURATION,
             finality_activation_height: DEFAULT_FINALITY_ACTIVATION_HEIGHT,
+            max_pub_rand_commit_offset: DEFAULT_MAX_PUB_RAND_COMMIT_OFFSET,
         }
     }
 }

--- a/packages/apis/src/finality_api.rs
+++ b/packages/apis/src/finality_api.rs
@@ -16,6 +16,7 @@ pub struct InstantiateMsg {
     pub missed_blocks_window: Option<u64>,
     pub jail_duration: Option<u64>,
     pub finality_activation_height: Option<u64>,
+    pub max_pub_rand_commit_offset: Option<u64>,
 }
 
 #[cw_serde]


### PR DESCRIPTION
This PR 

- replaces `MAX_PUB_RAND_COMMIT_OFFSET` const with a conig parameter, passed thru instantiation. This is because the reasonable value for it depends on the block time.
- gives a bigger default value since most Cosmos chains use much shorter block time than Babylon