### PR TITLE
bugfix: avoid gas limit by lowering max number of blocks per endBlock

### DIFF
--- a/contracts/btc-finality/src/tallying.rs
+++ b/contracts/btc-finality/src/tallying.rs
@@ -8,11 +8,10 @@ use cosmwasm_std::{DepsMut, Env, Event, StdResult, Storage};
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
 
-// Setting max amount of finalized blocks per EndBlock to 1_000 to cap processing time,
+// Setting max amount of finalized blocks per EndBlock to 200 to cap processing time,
 // mirroring Babylon's `MaxFinalizedRewardedBlocksPerEndBlock`.
 // https://github.com/babylonlabs-io/babylon/blob/53d1a8e211f5c9d8b369397bde1f6cf05c7038ad/x/finality/types/constants.go#L7
-// Setting a smaller value here because the cost in CosmWasm is higher than in Go module.
-const MAX_FINALIZED_REWARDED_BLOCKS_PER_END_BLOCK: u64 = 1_000;
+const MAX_FINALIZED_REWARDED_BLOCKS_PER_END_BLOCK: u64 = 200;
 
 /// Tries to finalise all blocks that are non-finalised AND have a non-nil
 /// finality provider set, from the earliest to the latest.


### PR DESCRIPTION
## Description 
We have a bug that when we try to commit a lot of blocks in batch we reach gas limit. The previous limit is 1k and it's a magic number. Lowered this by 5x to try to avoid gas limit error

## Error
`10:16PM ERR Failed to send EndBlock message to BTC finality contract error="contract call to bbnc1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqv7u2f2 panicked: {Wasm engine function execution}, gas_used: 5000000" module=x/babylon`