### PR TITLE
bugfix: out of gas on big batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
+- [#349](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/349) bugfix:
+  out of gas on big batch
 - [#345](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/345) fix:
   jailing issue in liveness check
 - [#348](https://github.com/babylonlabs-io/cosmos-bsn-contracts/pull/348) fix:

--- a/contracts/btc-finality/src/tallying.rs
+++ b/contracts/btc-finality/src/tallying.rs
@@ -8,11 +8,12 @@ use cosmwasm_std::{DepsMut, Env, Event, StdResult};
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
 
-// Setting max amount of finalized blocks per EndBlock to 1_000 to cap processing time,
+// Setting max amount of finalized blocks per EndBlock to 200 to cap processing time,
 // mirroring Babylon's `MaxFinalizedRewardedBlocksPerEndBlock`.
 // https://github.com/babylonlabs-io/babylon/blob/53d1a8e211f5c9d8b369397bde1f6cf05c7038ad/x/finality/types/constants.go#L7
-// Setting a smaller value here because the cost in CosmWasm is higher than in Go module.
-const MAX_FINALIZED_REWARDED_BLOCKS_PER_END_BLOCK: u64 = 1_000;
+// The cost in CosmWasm is higher than in Go module. Setting this value to a higher
+// value like 1_000 can cause an out of gas issue as the default gas limit is 5M.
+const MAX_FINALIZED_REWARDED_BLOCKS_PER_END_BLOCK: u64 = 200;
 
 /// Tries to finalise all blocks that are non-finalised AND have a non-nil
 /// finality provider set, from the earliest to the latest.

--- a/contracts/btc-finality/src/tallying.rs
+++ b/contracts/btc-finality/src/tallying.rs
@@ -11,8 +11,6 @@ use std::collections::{HashMap, HashSet};
 // Setting max amount of finalized blocks per EndBlock to 200 to cap processing time,
 // mirroring Babylon's `MaxFinalizedRewardedBlocksPerEndBlock`.
 // https://github.com/babylonlabs-io/babylon/blob/53d1a8e211f5c9d8b369397bde1f6cf05c7038ad/x/finality/types/constants.go#L7
-// The cost in CosmWasm is higher than in Go module. Setting this value to a higher
-// value like 1_000 can cause an out of gas issue as the default gas limit is 5M.
 const MAX_FINALIZED_REWARDED_BLOCKS_PER_END_BLOCK: u64 = 200;
 
 /// Tries to finalise all blocks that are non-finalised AND have a non-nil


### PR DESCRIPTION
## Description

This PR fixes the default size for `MAX_FINALIZED_REWARDED_BLOCKS_PER_END_BLOCK`. The previous default of `1_000` was too large for the default block gas limit and caused runtime errors when sending the `EndBlock` message to the BTC finality contract. With `1_000`, we observed panics such as:
```
10:16PM ERR Failed to send EndBlock message to BTC finality contract error="contract call to bbnc1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqv7u2f2 panicked: {Wasm engine function execution}, gas_used: 5000000" module=x/babylon
```
To prevent this, we picked a more conservative default range that fits safely within the block gas limit, ensuring EndBlock execution will not exceed gas and panic under normal conditions.
